### PR TITLE
[KAIZEN-0] bruker window.location for å bygge url til feature

### DIFF
--- a/app-config-fss.yaml
+++ b/app-config-fss.yaml
@@ -63,6 +63,8 @@ fasitResources:
     propertyMap:
       url: PUBLIC_VEILARBVEILEDER_URL
 
+    # nais konfigurerer ikke riktig url i fasit, bruker window.location.origin til å bygge url,
+    # men lar denne avhengigheten være for å vise avhengigheten
   - alias: feature_endpoint
     resourceType: restservice
     propertyMap:

--- a/src/environment.js
+++ b/src/environment.js
@@ -39,9 +39,6 @@ export const VEILEDER_BASE_URL = getEnviromentVariable(
     true
 );
 
-export const FEATURE_BASE_URL = getEnviromentVariable(
-    'FEATURE_ENDPOINT_URL',
-    true
-);
+export const FEATURE_BASE_URL = `${window.location.origin}/feature`;
 
 export default {};


### PR DESCRIPTION
Nais eksponerer feil url til fasit så vi bruker window.location.origin
+ /feature istedenfor å bruker fasit-ressursen.