### PR TITLE
FO-851 Create Dockerfile for running e2e-tests

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,26 @@
+FROM docker.adeo.no:5000/pus/toolbox
+
+ADD . /source
+WORKDIR /source
+
+# Chrome and Firefox browser deps
+RUN apt-get update
+RUN apt-get -qqy --no-install-recommends install -y \
+libxi6 \
+libgconf-2-4 \
+xvfb \
+fonts-liberation \
+libappindicator3-1 \
+libgtk-3-0 \
+libxss1 \
+xdg-utils \
+bzip2 \
+gconf-service
+
+# Chrome browser binary
+RUN wget --no-check-certificate https://dl-ssl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN dpkg -i google-chrome-stable_current_amd64.deb
+
+RUN npm install
+
+CMD ["npm", "run", "test:e2e"]


### PR DESCRIPTION
Pipeline will look for a file named `Dockerfile.e2e` and consequently build and run this as a separate test step.