### PR TITLE
[FO-943] Oppfolgingsenhet ved tilordning

### DIFF
--- a/example/mocks/index.js
+++ b/example/mocks/index.js
@@ -20,6 +20,7 @@ import veilederTilgang from './veilederTilgang';
 import veiledere from './veiledere';
 import enheter from './enheter';
 import feature from './feature';
+import oppfoelgingsstatus from './oppfoelgingsstatus';
 import fetchMock from 'yet-another-fetch-mock';
 import { fetchmockMiddleware } from './utils';
 
@@ -76,7 +77,6 @@ mock.post('/veilarbdialog/api/dialog', ({ body }) => opprettDialog(body));
 //veilarbdialogproxy
 mock.get('/veilarbdialogproxy/api/dialog', dialog);
 
-
 // veilarbaktivitet-api
 mock.get('/veilarbaktivitet/api/aktivitet/kanaler', [
     'internett',
@@ -111,11 +111,11 @@ mock.put(
 
 //veilarbaktivitetproxy
 mock.get('/veilarbaktivitetproxy/api/aktivitet/arena', arena);
-mock.get('/veilarbaktivitetproxy/api/aktivitet/:aktivitetId', ({ pathParams }) =>
-    getAktivitet(pathParams.aktivitetId)
+mock.get(
+    '/veilarbaktivitetproxy/api/aktivitet/:aktivitetId',
+    ({ pathParams }) => getAktivitet(pathParams.aktivitetId)
 );
 mock.get('/veilarbaktivitetproxy/api/aktivitet', aktiviteter);
-
 
 //veilarbperson-api
 mock.get('/veilarbperson/api/person/:fnr', ({ pathParams }) =>
@@ -123,10 +123,14 @@ mock.get('/veilarbperson/api/person/:fnr', ({ pathParams }) =>
 );
 
 //veilarbveileder-api
-mock.get(
-    '/veilarbveileder/api/enhet/:enhetNr/veiledere',
-    ({ pathParams }) => veiledere
-);
+mock.get('/veilarbveileder/api/enhet/:enhetNr/veiledere', ({ pathParams }) => {
+    // 9999 er oppfolgingsenhet, som stortsett er den som skal brukes av aktivitetsplanen
+    // 007 er geografiskenhet, men per i dag er vi ikke interessert i denne her.
+    if (pathParams.enhetNr !== '9999') {
+        throw new Error('Har nok spurt om feil enhet her?');
+    }
+    return veiledere;
+});
 
 //veilarboppgave-api
 mock.get('/veilarboppgave/api/enheter', ({ queryParams }) => enheter);
@@ -137,3 +141,8 @@ mock.post('/veilarboppfolging/api/tilordneveileder', ({ body }) => {
         resultat: 'OK: Veiledere tilordnet',
     };
 });
+
+mock.get(
+    '/veilarboppfolging/api/person/:fnr/oppfoelgingsstatus',
+    oppfoelgingsstatus
+);

--- a/example/mocks/oppfoelgingsstatus.js
+++ b/example/mocks/oppfoelgingsstatus.js
@@ -1,0 +1,10 @@
+export default {
+    rettighetsgruppe: 'IYT',
+    formidlingsgruppe: 'ISERV',
+    servicegruppe: 'IVURD',
+    oppfolgingsenhet: {
+        navn: 'NAV TEST',
+        enhetId: '9999',
+    },
+    inaktiveringsdato: '2018-03-13T12:00:00+01:00',
+};

--- a/src/moduler/oppfoelgingsstatus/oppfoelgingsstatus-api.js
+++ b/src/moduler/oppfoelgingsstatus/oppfoelgingsstatus-api.js
@@ -1,0 +1,10 @@
+import { OPPFOLGING_BASE_URL } from '../../environment';
+import { fetchToJson } from '../../ducks/utils';
+
+export function hentOppfolgingsstatus(fnr) {
+    return fetchToJson(
+        `${OPPFOLGING_BASE_URL}/person/${fnr}/oppfoelgingsstatus`
+    );
+}
+
+export default {};

--- a/src/moduler/oppfoelgingsstatus/oppfoelgingsstatus-reducer.js
+++ b/src/moduler/oppfoelgingsstatus/oppfoelgingsstatus-reducer.js
@@ -1,0 +1,10 @@
+import * as Api from './oppfoelgingsstatus-api';
+import { createActionsAndReducer } from '../../ducks/rest-reducer';
+
+const { reducer, cashedAction } = createActionsAndReducer('oppfoelgingsstatus');
+
+export default reducer;
+
+export function hentOppfolgingsstatus(fnr) {
+    return cashedAction(() => Api.hentOppfolgingsstatus(fnr));
+}

--- a/src/moduler/oppfoelgingsstatus/oppfoelgingsstatus-selector.js
+++ b/src/moduler/oppfoelgingsstatus/oppfoelgingsstatus-selector.js
@@ -1,0 +1,11 @@
+export function selectOppfoelgingsstatusSlice(state) {
+    return state.data.oppfoelgingsstatus;
+}
+
+export function selectOppfoelgingsstatusStatus(state) {
+    return selectOppfoelgingsstatusSlice(state).status;
+}
+
+export function selectOppfoelgingsstatusData(state) {
+    return selectOppfoelgingsstatusSlice(state).data;
+}

--- a/src/moduler/tildel-veileder/tildel-veilder.less
+++ b/src/moduler/tildel-veileder/tildel-veilder.less
@@ -23,7 +23,5 @@
         box-shadow: 2px 2px 2px @navGra60;
         right: -0.5rem;
         border: 0;
-
     }
-
 }

--- a/src/moduler/tildel-veileder/tildel-veileder.js
+++ b/src/moduler/tildel-veileder/tildel-veileder.js
@@ -4,9 +4,9 @@ import SokFilter from './../../felles-komponenter/sok-filter/sok-filter';
 import Dropdown from './../../felles-komponenter/dropdown/dropdown';
 import * as AppPT from '../../proptypes';
 import RadioFilterForm from '../../felles-komponenter/radio-filterform/radio-filterform';
-import { hentBruker } from '../bruker/bruker-reducer';
+import { hentOppfolgingsstatus } from '../oppfoelgingsstatus/oppfoelgingsstatus-reducer';
 import Innholdslaster from '../../felles-komponenter/utils/innholdslaster';
-import { selectBrukerStatus } from '../bruker/bruker-selector';
+import { selectOppfoelgingsstatusStatus } from '../oppfoelgingsstatus/oppfoelgingsstatus-selector';
 import { getFodselsnummer } from '../../bootstrap/fnr-util';
 import { hentArbeidsliste } from '../arbeidsliste/arbeidsliste-reducer';
 import { tildelVeileder } from './tildel-veileder-reducer';
@@ -102,7 +102,10 @@ TildelVeileder.defaultProps = {
 const mapStateToProps = state => ({
     veilederliste: selectVeilederListe(state),
     veilederId: selectVeilederId(state),
-    avhengigheter: [selectBrukerStatus(state), selectVeilederStatus(state)],
+    avhengigheter: [
+        selectOppfoelgingsstatusStatus(state),
+        selectVeilederStatus(state),
+    ],
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -111,8 +114,8 @@ const mapDispatchToProps = dispatch => ({
             .then(() => dispatch(hentOppfolging(fnr)))
             .then(() => dispatch(hentArbeidsliste(fnr))),
     doHentVeiledereForEnhet: fnr =>
-        dispatch(hentBruker(fnr)).then(({ data }) =>
-            dispatch(hentVeiledereForEnhet(data.behandlendeEnhet.enhetsnummer))
+        dispatch(hentOppfolgingsstatus(fnr)).then(({ data }) =>
+            dispatch(hentVeiledereForEnhet(data.oppfolgingsenhet.enhetId))
         ),
 });
 

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -24,6 +24,7 @@ import veilederePaEnhetReducer from './moduler/veiledere-pa-enhet/veiledere-pa-e
 import tildelVeilederReducer from './moduler/tildel-veileder/tildel-veileder-reducer';
 import referatReducer from './moduler/aktivitet/aktivitet-referat-reducer';
 import oppfolgingReducer from './moduler/oppfolging-status/oppfolging-reducer';
+import oppfolgingstatusReducer from './moduler/oppfoelgingsstatus/oppfoelgingsstatus-reducer';
 import utskriftReducer from './moduler/utskrift/utskrift-duck';
 import versjonReducer from './moduler/aktivitet/aktivitet-versjoner/aktivitet-versjoner-reducer';
 import vilkarReducer from './moduler/vilkar/vilkar-reducer';
@@ -54,6 +55,7 @@ const combinedReducers = combineReducers({
         opprettOppgave: oppgaveReducer,
         referat: referatReducer,
         oppfolging: oppfolgingReducer,
+        oppfoelgingsstatus: oppfolgingstatusReducer,
         versjoner: versjonReducer,
         vilkar: vilkarReducer,
         feature: featureReducer,


### PR DESCRIPTION
Tildeling av veileder hentes veiledere utifra brukers
geografiske-enhet. Bytter om til a bruke brukers
oppfolgingsenhet, siden det er det riktige