### PR TITLE
KAIZEN-0: bruk .sr-only

### DIFF
--- a/src/felles-komponenter/modal/modal-header.js
+++ b/src/felles-komponenter/modal/modal-header.js
@@ -27,7 +27,7 @@ function ModalHeader({
             {/* header til slutt for å få denne sist i tabrekkefølgen */}
 
             <header className="modal-header">
-                <span aria-live="assertive" className="kun-for-skjermleser">
+                <span aria-live="assertive" className="sr-only">
                     {aktivitetErLaast
                         ? intl.formatMessage({
                               id: 'aktivitetsmodal.kan.ikke.redigeres',

--- a/src/felles-komponenter/tall-alert.js
+++ b/src/felles-komponenter/tall-alert.js
@@ -9,7 +9,7 @@ function TallAlert({ children }) {
             <span aria-hidden="true">
                 {children}
             </span>
-            <span className="kun-for-skjermleser">
+            <span className="sr-only">
                 <FormattedMessage
                     id="tall-alert.antall.skjermleser"
                     values={{ ULESTE_MELDINGER: children }}

--- a/src/felles-komponenter/tall-alert.less
+++ b/src/felles-komponenter/tall-alert.less
@@ -14,11 +14,3 @@
         background-color: @navRodDarken20;
     }
 }
-
-.kun-for-skjermleser {
-    position: absolute;
-    left: -10000px;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-}

--- a/src/moduler/aktivitet/aktivitet-kort/aktivitetskort-tillegg.js
+++ b/src/moduler/aktivitet/aktivitet-kort/aktivitetskort-tillegg.js
@@ -31,7 +31,7 @@ function AktivitetskortTillegg({
                 </TallAlert>
                 <HiddenIfDiv
                     hidden={antallUlesteHenvendelser > 0}
-                    className="kun-for-skjermleser"
+                    className="sr-only"
                 >
                     <FormattedMessage id="aktivitetskort-dialog-tidligere-meldinger" />
                 </HiddenIfDiv>


### PR DESCRIPTION
Viser seg at .kun-for-skjermleser gir visningsfeil i drag & drop
for noen browsere. .sr-only løser problemet og kommer fra felles
bibloteket