### PR TITLE
Fo 1295 infotekst til inaktivert brukere

### DIFF
--- a/example/mocks/oppfolging.js
+++ b/example/mocks/oppfolging.js
@@ -22,6 +22,8 @@ const oppfolging = {
         },
     ],
     harSkriveTilgang: true,
+    kanReaktiveres: true,
+    inaktiveringsdato: '2018-08-31T10:46:10.971+01:00',
 };
 
 export default function(queryParams, changeFn = ob => ob) {

--- a/src/moduler/oppfoelgingsstatus/oppfoelgingsstatus-selector.js
+++ b/src/moduler/oppfoelgingsstatus/oppfoelgingsstatus-selector.js
@@ -21,3 +21,7 @@ export function selectErBrukerInaktivIArena(state) {
 export function selectErBrukerAktivIArena(state) {
     return !selectErBrukerInaktivIArena(state);
 }
+
+export function selectInaktiveringsDato(state) {
+    return selectOppfoelgingsstatusData(state).inaktiveringsdato;
+}

--- a/src/moduler/oppfoelgingsstatus/oppfoelgingsstatus-selector.js
+++ b/src/moduler/oppfoelgingsstatus/oppfoelgingsstatus-selector.js
@@ -21,7 +21,3 @@ export function selectErBrukerInaktivIArena(state) {
 export function selectErBrukerAktivIArena(state) {
     return !selectErBrukerInaktivIArena(state);
 }
-
-export function selectInaktiveringsDato(state) {
-    return selectOppfoelgingsstatusData(state).inaktiveringsdato;
-}

--- a/src/moduler/oppfolging-status/oppfolging-selector.js
+++ b/src/moduler/oppfolging-status/oppfolging-selector.js
@@ -116,3 +116,11 @@ export function selectHarSkriveTilgang(state) {
     return harSkriveTilgang === undefined || harSkriveTilgang;
     // For å kunne være bakoverkompatiblem med at oppfolgingStatus ikke returnerer dene propertien.
 }
+
+export function selectKanReaktiveres(state) {
+    return selectOppfolgingData(state).kanReaktiveres;
+}
+
+export function selectInaktiveringsDato(state) {
+    return selectOppfolgingData(state).inaktiveringsdato;
+}

--- a/src/moduler/varslinger/varsel-alertstriper.js
+++ b/src/moduler/varslinger/varsel-alertstriper.js
@@ -72,6 +72,40 @@ AdvarselVarsling.propTypes = {
     className: PT.string,
 };
 
+export function AdvarselMedLenkeVarsling({
+    tekstId,
+    lenkeTekstId,
+    href,
+    className,
+    onClick,
+    values,
+}) {
+    return (
+        <AlertStripeAdvarsel className={className}>
+            <FormattedMessage id={tekstId} values={values} />&nbsp;
+            <Lenke href={href} onClick={onClick}>
+                <FormattedMessage id={lenkeTekstId} />
+            </Lenke>
+        </AlertStripeAdvarsel>
+    );
+}
+
+AdvarselMedLenkeVarsling.defaultProps = {
+    className: '',
+    onClick: () => {},
+    values: undefined,
+};
+
+AdvarselMedLenkeVarsling.propTypes = {
+    tekstId: PT.string.isRequired,
+    lenkeTekstId: PT.string.isRequired,
+    href: PT.string.isRequired,
+    className: PT.string,
+    onClick: PT.func,
+    values: PT.object,
+};
+
 export const HiddenIfVarsling = hiddenIf(Varsling);
 export const HiddenIfVarslingMedLenke = hiddenIf(VarslingMedLenke);
 export const HiddenIfAdvarselVarsling = hiddenIf(AdvarselVarsling);
+export const HiddenIfAdvarselMedLenke = hiddenIf(AdvarselMedLenkeVarsling);

--- a/src/moduler/varslinger/varslinger.js
+++ b/src/moduler/varslinger/varslinger.js
@@ -2,12 +2,14 @@ import React, { Component } from 'react';
 import PT from 'prop-types';
 import { connect } from 'react-redux';
 import { Container } from 'nav-frontend-grid';
+import { moment } from '../../utils';
 import { hentIdentitet } from '../identitet/identitet-reducer';
 import Innholdslaster from '../../felles-komponenter/utils/innholdslaster';
 import * as AppPT from '../../proptypes';
 import {
     HiddenIfVarsling,
     HiddenIfVarslingMedLenke,
+    HiddenIfAdvarselMedLenke,
 } from './varsel-alertstriper';
 import {
     selectVilkarMaBesvares,
@@ -18,6 +20,8 @@ import {
     selectErEskalert,
     selectOppfolgingStatus,
     selectErUnderKvp,
+    selectInaktiveringsDato,
+    selectKanReaktiveres,
 } from '../oppfolging-status/oppfolging-selector';
 import {
     selectErBruker,
@@ -31,14 +35,34 @@ import { velgHistoriskPeriode } from '../filtrering/filter/filter-reducer';
 import { SLETT_BEGRUNNELSE_ACTION } from '../innstillinger/innstillinger-reducer';
 import { getFodselsnummer } from '../../bootstrap/fnr-util';
 import { hentOppfolgingsstatus } from '../oppfoelgingsstatus/oppfoelgingsstatus-reducer';
+import { hentOppfolging } from '../oppfolging-status/oppfolging-reducer';
 
 class Varslinger extends Component {
     componentDidMount() {
         this.props.doHentIdentitet();
         if (!this.props.erBruker) {
             this.props.doHentOppfolgingsstatus(getFodselsnummer());
+        } else {
+            this.props.doHentOppfolging();
+            this.hentInfotekstTilInaktivertBrukere(this.props.antallDagerIgjen);
         }
     }
+
+    hentInfotekstTilInaktivertBrukere() {
+        const antalldagerIgjen = this.props.antallDagerIgjen;
+        const antallDagerIgjenMerEnn10 =
+            antalldagerIgjen <= 28 && antalldagerIgjen >= 10;
+        const antallDagerIgjenMindreEnn10 =
+            antalldagerIgjen < 10 && antalldagerIgjen >= 1;
+
+        if (antallDagerIgjenMerEnn10) {
+            return 'oppfolging.inaktivert-28-til-10-dager.reaktiveres';
+        } else if (antallDagerIgjenMindreEnn10) {
+            return 'oppfolging.inaktivert-mindre-enn-10-dager.reaktiveres';
+        }
+        return 'oppfolging.inaktivert-mer-enn-28-dager.reaktiveres';
+    }
+
     render() {
         const {
             erBruker,
@@ -54,7 +78,11 @@ class Varslinger extends Component {
             doVelgNavarendePeriode,
             slettBegrunnelse,
             erUnderKvp,
+            kanReaktiveres,
+            antallDagerIgjen,
         } = this.props;
+
+        const reaktiveringsInfoTekst = this.hentInfotekstTilInaktivertBrukere();
 
         const visVarslingerForBruker = (
             <Container>
@@ -67,6 +95,14 @@ class Varslinger extends Component {
                     onClick={() => {
                         doVelgNavarendePeriode();
                     }}
+                />
+                <HiddenIfAdvarselMedLenke
+                    hidden={!kanReaktiveres}
+                    tekstId={reaktiveringsInfoTekst}
+                    className="varsling"
+                    lenkeTekstId="oppfolging.ikke-under-oppfolging.reaktiveres.lenke-tekst"
+                    href="https://tjenester.nav.no/arbeidssokerregistrering/start"
+                    values={{ antalldagerIgjen: antallDagerIgjen }}
                 />
             </Container>
         );
@@ -146,6 +182,8 @@ Varslinger.defaultProps = {
     historiskVisning: false,
     tilhorendeDialogId: undefined,
     erUnderKvp: false,
+    kanReaktiveres: false,
+    antallDagerIgjen: undefined,
 };
 
 Varslinger.propTypes = {
@@ -164,29 +202,42 @@ Varslinger.propTypes = {
     brukerErEskalert: PT.bool,
     tilhorendeDialogId: PT.number,
     erUnderKvp: PT.bool,
+    doHentOppfolging: PT.func.isRequired,
+    kanReaktiveres: PT.bool,
+    antallDagerIgjen: PT.number,
 };
 
-const mapStateToProps = state => ({
-    erBruker: selectErBruker(state),
-    avhengigheter: [
-        selectOppfolgingStatus(state),
-        selectIdentitetStatus(state),
-    ],
-    innsideAvhengigheter: [selectOppfoelgingsstatusStatus(state)],
-    brukerErAktivIArena: selectErBrukerAktivIArena(state),
-    vilkarMaBesvares: selectVilkarMaBesvares(state),
-    underOppfolging: selectErUnderOppfolging(state),
-    brukerErManuell: selectErBrukerManuell(state),
-    reservertIKRR: selectReservasjonKRR(state),
-    brukerErEskalert: selectErEskalert(state),
-    tilhorendeDialogId: selectTilHorendeDialogId(state),
-    erUnderKvp: selectErUnderKvp(state),
-});
+const mapStateToProps = state => {
+    const dagensDato = moment();
+    const inaktiveringsdato = selectInaktiveringsDato(state);
+    const dato28dagerEtterIserv = moment(inaktiveringsdato).add(28, 'day');
+    const antalldagerIgjen = dato28dagerEtterIserv.diff(dagensDato, 'days');
+
+    return {
+        erBruker: selectErBruker(state),
+        avhengigheter: [
+            selectOppfolgingStatus(state),
+            selectIdentitetStatus(state),
+        ],
+        innsideAvhengigheter: [selectOppfoelgingsstatusStatus(state)],
+        brukerErAktivIArena: selectErBrukerAktivIArena(state),
+        vilkarMaBesvares: selectVilkarMaBesvares(state),
+        underOppfolging: selectErUnderOppfolging(state),
+        brukerErManuell: selectErBrukerManuell(state),
+        reservertIKRR: selectReservasjonKRR(state),
+        brukerErEskalert: selectErEskalert(state),
+        tilhorendeDialogId: selectTilHorendeDialogId(state),
+        erUnderKvp: selectErUnderKvp(state),
+        kanReaktiveres: selectKanReaktiveres(state),
+        antallDagerIgjen: antalldagerIgjen,
+    };
+};
 
 const mapDispatchToProps = dispatch => ({
     doHentIdentitet: () => dispatch(hentIdentitet()),
     doVelgNavarendePeriode: () => dispatch(velgHistoriskPeriode(null)),
     doHentOppfolgingsstatus: fnr => dispatch(hentOppfolgingsstatus(fnr)),
+    doHentOppfolging: () => dispatch(hentOppfolging()),
     slettBegrunnelse: () => dispatch(SLETT_BEGRUNNELSE_ACTION),
 });
 

--- a/tekster/nb/oppfolging.ikke-under-oppfolging.reaktiveres.lenke-tekst_nb.txt
+++ b/tekster/nb/oppfolging.ikke-under-oppfolging.reaktiveres.lenke-tekst_nb.txt
@@ -1,0 +1,1 @@
+Gå til registrering

--- a/tekster/nb/oppfolging.inaktivert-28-til-10-dager.reaktiveres_nb.txt
+++ b/tekster/nb/oppfolging.inaktivert-28-til-10-dager.reaktiveres_nb.txt
@@ -1,0 +1,1 @@
+Du er ikke lenger registrert hos NAV. Hvis du fortsatt skal motta ytelser, få oppfølging fra NAV og bruke aktivitetsplanen må du være registrert.

--- a/tekster/nb/oppfolging.inaktivert-mer-enn-28-dager.reaktiveres_nb.txt
+++ b/tekster/nb/oppfolging.inaktivert-mer-enn-28-dager.reaktiveres_nb.txt
@@ -1,0 +1,1 @@
+Du er ikke lenger registrert hos NAV og din tidligere aktivitetsplan er lagt under "Tidligere plan". Hvis du fortsatt skal motta ytelser og få oppfølging fra NAV må du være registrert.

--- a/tekster/nb/oppfolging.inaktivert-mindre-enn-10-dager.reaktiveres_nb.txt
+++ b/tekster/nb/oppfolging.inaktivert-mindre-enn-10-dager.reaktiveres_nb.txt
@@ -1,0 +1,1 @@
+Du er ikke lenger registrert hos NAV. Hvis du fortsatt skal motta ytelser, få oppfølging fra NAV og bruke aktivitetsplanen må du være registrert. Om {antalldagerIgjen} dager vil denne aktivitetsplanen bli avsluttet.


### PR DESCRIPTION
Akseptansekriterier
Gitt at bruker er i aktivitetsplan og har vært inaktiv i mindre enn 28 dager og det er mellom 28-10 dager igjen
    a) så skal jeg se en alertstripe advarsel med teksten "Du er ikke lenger registrert hos NAV. Hvis du fortsatt skal motta ytelser, få oppfølging fra NAV og bruke aktivitetsplanen må du være registrert. Gå til registrering" 
     b) så skal jeg kunne klikke på "gå til registrering" som er en lenke som fører meg til reaktivering
Gitt at bruker er i aktivitetsplan og har vært inaktiv i mindre enn 28 dager og det er færre enn 10 dager igjen
    a) så skal jeg se en alertstripe advarsel med teksten "Du er ikke lenger registrert hos NAV. Hvis du fortsatt skal motta ytelser, få oppfølging fra NAV og bruke aktivitetsplanen må du være registrert. Om x dager vil denne aktivitetsplanen bli avsluttet. Gå til registrering". Der x viser hvor mange dager det er igjen
     b) så skal jeg kunne klikke på "gå til registrering" som er en lenke som fører meg til reaktivering
Gitt at bruker er i aktivitetsplan og har vært inaktiv i mer enn eller lik 28 dager
    a) så skal jeg se en alertstripe advarsel med teksten "Du er ikke lenger registrert hos NAV og din tidligere aktivitetsplan er lagt under "Tidligere plan". Hvis du fortsatt skal motta ytelser og få oppfølging fra NAV må du være registrert. Gå til registrering" 
     b) så skal jeg kunne klikke på "gå til registrering" som er en lenke som fører meg til reaktivering