### PR TITLE
KAIZEN-0: Send aktiviteten når den publiseres

### DIFF
--- a/src/moduler/aktivitet/aktivitet-api.js
+++ b/src/moduler/aktivitet/aktivitet-api.js
@@ -46,9 +46,10 @@ export function hentKanaler() {
     return fetchToJson(`${AKTIVITET_BASE_URL}/aktivitet/kanaler`);
 }
 
-export function publiserReferat(aktivitetId) {
+export function publiserReferat(aktivitet) {
     return putAsJson(
-        `${AKTIVITET_BASE_URL}/aktivitet/${aktivitetId}/referat/publiser`
+        `${AKTIVITET_BASE_URL}/aktivitet/${aktivitet.id}/referat/publiser`,
+        aktivitet
     );
 }
 

--- a/src/moduler/aktivitet/aktivitet-referat-reducer.js
+++ b/src/moduler/aktivitet/aktivitet-referat-reducer.js
@@ -33,9 +33,12 @@ export function oppdaterReferat(aktivitet) {
 }
 
 export function publiserReferat(aktivitet) {
-    return doThenDispatch(() => Api.publiserReferat(aktivitet.id), {
-        OK: AT.PUBLISER_REFERAT_OK,
-        FEILET: AT.PUBLISER_REFERAT_FEILET,
-        PENDING: AT.PUBLISER_REFERAT,
-    });
+    return doThenDispatch(
+        () => Api.publiserReferat({ ...aktivitet, erReferatPublisert: true }),
+        {
+            OK: AT.PUBLISER_REFERAT_OK,
+            FEILET: AT.PUBLISER_REFERAT_FEILET,
+            PENDING: AT.PUBLISER_REFERAT,
+        }
+    );
 }


### PR DESCRIPTION
Dette er både for å forenkle api-et og for å sjekke at vi ikke får
versjonskonflikt når endringen skjer