### PR TITLE
FO-2013 La til event når dialog blir lest

### DIFF
--- a/src/moduler/dialog/dialog-modal/henvendelser.js
+++ b/src/moduler/dialog/dialog-modal/henvendelser.js
@@ -127,7 +127,10 @@ const mapDispatchToProps = (dispatch, props) => {
     return {
         doMarkerDialogSomLest: () => {
             if (!dialog.lest) {
-                markerDialogSomLest(dialogId)(dispatch);
+                markerDialogSomLest(dialogId)(dispatch)
+                    .then(() => {
+                        window.dispatchEvent(new Event('aktivitetsplan.dialog.lest'));
+                    });
             }
         },
     };


### PR DESCRIPTION
For at veilarbpersonflatefs skal få vite når dialoger blir lest, så må det legges på et event når det blir gjort kall mot /les i veilarbdialog