### PR TITLE
FO-2241: demodashbord hvor man kan bytte brukertype og modus

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,8 +22,10 @@
 </head>
 <body style="background-color: white">
     <div id="modal-a11y-wrapper">
+        <div id="demo"></div>
         <div id="mainapp" class="appContainer"></div>
     </div>
+
 </body>
 <script>
     function render() {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import App from './app';
 import NAVSPA from './NAVSPA';
 import * as ReactDOM from 'react-dom';
 import DemoDashboard from './mocks/demoDashboard'
-import { hentFraSessionStorage, SessionStorageElement } from "./mocks/sessionstorage";
+import { erEksternBruker } from "./mocks/sessionstorage";
 import { eksternBrukerConfig, veilederConfig } from "./mocks/appconfig";
 
 /* eslint-disable global-require */
@@ -16,8 +16,7 @@ if (!global.Intl) {
 
 if (process.env.REACT_APP_MOCK === 'true') {
 
-    const erEksternBruker = hentFraSessionStorage(SessionStorageElement.EKSTERN_BRUKER) === 'true';
-    if (erEksternBruker) {
+    if (erEksternBruker()) {
         window.history.replaceState('', '', `/`);
         window.appconfig = eksternBrukerConfig;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,11 @@ import './polyfill'
 import React from 'react';
 import ReactModal from 'react-modal';
 import App from './app';
-import {fnrFraUrl} from "./bootstrap/fnr-provider";
 import NAVSPA from './NAVSPA';
+import * as ReactDOM from 'react-dom';
+import DemoDashboard from './mocks/demoDashboard'
+import { hentFraSessionStorage, SessionStorageElement } from "./mocks/sessionstorage";
+import { eksternBrukerConfig, veilederConfig } from "./mocks/appconfig";
 
 /* eslint-disable global-require */
 if (!global.Intl) {
@@ -13,23 +16,25 @@ if (!global.Intl) {
 
 if (process.env.REACT_APP_MOCK === 'true') {
 
-    // NOTE: This is bad, don't use it if you dont HAVE to
-    window.appconfig = {
-        CONTEXT_PATH: '',
-        TILLAT_SET_AVTALT: true,
-        VIS_SIDEBANNER: true,
-        FNR_I_URL: true,
-        VIS_MALER: true,
-    };
+    const erEksternBruker = hentFraSessionStorage(SessionStorageElement.EKSTERN_BRUKER) === 'true';
+    if (erEksternBruker) {
+        window.history.replaceState('', '', `/`);
+        window.appconfig = eksternBrukerConfig;
+    }
+    else {
+        window.history.replaceState('12345678910', '', `/12345678910`);
+        window.appconfig = veilederConfig
+    }
 
     console.log('=========================='); // eslint-disable-line no-console
     console.log('======== MED MOCK ========'); // eslint-disable-line no-console
     console.log('=========================='); // eslint-disable-line no-console
     require('./mocks'); // eslint-disable-line global-require
 
-    if (!fnrFraUrl() && window.appconfig.FNR_I_URL) {
-        window.history.replaceState('12345678910', '', `/12345678910`);
-    }
+    ReactDOM.render(
+        <DemoDashboard/>,
+        document.getElementById('demo')
+    );
 }
 
 function AppWrapper(props) {

--- a/src/mocks/aktivitet.js
+++ b/src/mocks/aktivitet.js
@@ -1,6 +1,9 @@
 import moment from 'moment';
 import { rndId } from './utils';
-import me from './me';
+import { erEksternBruker } from './sessionstorage';
+
+const eksternBruker = erEksternBruker();
+const bruker = eksternBruker? 'BRUKER' : 'NAV';
 
 const aktiviteter = [
     wrapAktivitet({
@@ -233,10 +236,11 @@ export function opprettAktivitet(aktivitet) {
     const newAktivitet = wrapAktivitet({
         id: rndId(),
         opprettetDato: new Date(),
-        lagtInnAv: me.erBruker === true ? 'BRUKER' : 'NAV',
+        lagtInnAv: bruker,
         endretDato: moment().toISOString(),
-        endretAv: me.id,
+        endretAv: null,
         versjon: '1',
+        erLestAvBruker: eksternBruker,
         ...aktivitet,
     });
     aktiviteter.push(newAktivitet);
@@ -249,8 +253,8 @@ export function oppdaterAktivitet(aktivitetId, aktivitet) {
     );
     Object.assign(oldAktivitet, aktivitet);
     oldAktivitet.endretDato = moment().toISOString();
-    oldAktivitet.endretAv = me.id;
-    oldAktivitet.lagtInnAv = me.erBruker === true ? 'BRUKER' : 'NAV';
+    oldAktivitet.endretAv = bruker;
+    oldAktivitet.lagtInnAv = bruker;
 
     return oldAktivitet;
 }

--- a/src/mocks/appconfig.js
+++ b/src/mocks/appconfig.js
@@ -1,0 +1,18 @@
+// NOTE: This is bad, don't use it if you don't HAVE to
+export const veilederConfig = {
+    CONTEXT_PATH: '',
+    TILLAT_SET_AVTALT: true,
+    VIS_SIDEBANNER: false,
+    FNR_I_URL: true,
+    VIS_MALER: true,
+    TIMEOUTBOX: false
+};
+
+export const eksternBrukerConfig = {
+    CONTEXT_PATH: '',
+    TILLAT_SET_AVTALT: false,
+    VIS_SIDEBANNER: true,
+    FNR_I_URL: false,
+    VIS_MALER: false,
+    TIMEOUTBOX: true
+};

--- a/src/mocks/demoDashboard.js
+++ b/src/mocks/demoDashboard.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Innholdstittel } from 'nav-frontend-typografi';
 import {CheckboksPanelGruppe, RadioPanelGruppe} from 'nav-frontend-skjema';
-import { SessionStorageElement, hentFraSessionStorage, settSessionStorage } from "./sessionstorage";
+import {
+    SessionStorageElement,
+    settSessionStorage,
+    erEksternBruker,
+    erPrivatBruker
+} from "./sessionstorage";
 
 const brukertype = {
     ekstern: 'eksternbruker',
@@ -29,7 +34,7 @@ class DemoDashboard extends React.Component {
     };
 
     getBrukerType = () => {
-       if(hentFraSessionStorage(SessionStorageElement.EKSTERN_BRUKER) === 'true') {
+       if(erEksternBruker()) {
            return brukertype.ekstern;
        }
        else return brukertype.veileder;
@@ -57,7 +62,7 @@ class DemoDashboard extends React.Component {
                         {
                             label: 'Ikke under oppfølging',
                             id: SessionStorageElement.PRIVAT_BRUKER,
-                            checked: hentFraSessionStorage(SessionStorageElement.PRIVAT_BRUKER) === 'true'
+                            checked: erPrivatBruker()
                         }
                     ]}
                     onChange={this.endreTilstand}

--- a/src/mocks/demoDashboard.js
+++ b/src/mocks/demoDashboard.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Innholdstittel } from 'nav-frontend-typografi';
+import {CheckboksPanelGruppe, RadioPanelGruppe} from 'nav-frontend-skjema';
+import { SessionStorageElement, hentFraSessionStorage, settSessionStorage } from "./sessionstorage";
+
+const brukertype = {
+    ekstern: 'eksternbruker',
+    veileder: 'veilederbruker'
+
+};
+
+class DemoDashboard extends React.Component {
+
+    endreTilstand = (e) => {
+        const element = e.currentTarget;
+
+        if(element.id === SessionStorageElement.PRIVAT_BRUKER){
+            settSessionStorage(SessionStorageElement.PRIVAT_BRUKER, element.checked);
+            window.location.reload();
+        }
+    };
+
+    endreBrukerType = (e) => {
+        const element = e.currentTarget;
+        const erVeileder = element.id === brukertype.veileder;
+
+        settSessionStorage(SessionStorageElement.EKSTERN_BRUKER, !erVeileder);
+        window.location.reload();
+    };
+
+    getBrukerType = () => {
+       if(hentFraSessionStorage(SessionStorageElement.EKSTERN_BRUKER) === 'true') {
+           return brukertype.ekstern;
+       }
+       else return brukertype.veileder;
+    };
+
+    render() {
+        return (
+            <section className="demodashboard">
+                <Innholdstittel className="blokk-s">
+                    DEMO
+                </Innholdstittel>
+                <RadioPanelGruppe
+                    legend="Brukertype"
+                    name="brukertype-rdio-panel"
+                    radios={[
+                        { label: 'Veileder', id: brukertype.veileder, value: brukertype.veileder },
+                        { label: 'Eksternbruker', id: brukertype.ekstern, value: brukertype.ekstern }
+                    ]}
+                    checked={this.getBrukerType()}
+                    onChange={this.endreBrukerType}
+                />
+                <CheckboksPanelGruppe
+                    legend="Tilstand"
+                    checkboxes={[
+                        {
+                            label: 'Ikke under oppfølging',
+                            id: SessionStorageElement.PRIVAT_BRUKER,
+                            checked: hentFraSessionStorage(SessionStorageElement.PRIVAT_BRUKER) === 'true'
+                        }
+                    ]}
+                    onChange={this.endreTilstand}
+                />
+            </section>
+        )
+    }
+}
+
+export default DemoDashboard;

--- a/src/mocks/dialog.js
+++ b/src/mocks/dialog.js
@@ -1,4 +1,5 @@
 import { rndId } from './utils';
+import { erEksternBruker } from "./sessionstorage";
 
 const dialoger = [
     {
@@ -165,7 +166,7 @@ export function opprettDialog(update) {
     const nyHenvendelse = {
         id: rndId(),
         dialogId: dialogId,
-        avsender: 'VEILEDER',
+        avsender: erEksternBruker()? 'BRUKER':'VEILEDER',
         avsenderId: 'Z123456',
         overskrift: update.overskrift,
         tekst: update.tekst,

--- a/src/mocks/mal.js
+++ b/src/mocks/mal.js
@@ -1,3 +1,5 @@
+import { erEksternBruker } from "./sessionstorage";
+
 export const maler = [
     {
         mal: 'Jeg vil bli sjørøver',
@@ -15,10 +17,10 @@ export function sisteMal() {
     return maler[maler.length - 1];
 }
 
-export function opprettMal(update, erVeileder) {
+export function opprettMal(update) {
     let nyMal = {
         mal: update.mal,
-        endretAv: erVeileder ? 'VEILEDER' : 'BRUKER',
+        endretAv: erEksternBruker() ? 'BRUKER': 'VEILEDER',
         dato: new Date(),
     };
     maler.push(nyMal);

--- a/src/mocks/me.js
+++ b/src/mocks/me.js
@@ -1,4 +1,4 @@
-import { hentFraSessionStorage, SessionStorageElement } from "./sessionstorage";
+import { erEksternBruker } from "./sessionstorage";
 
 const eksternbruker = {
     id: '1234567890',
@@ -12,7 +12,7 @@ const veileder = {
     erBruker: false,
 };
 
-const erEksternbruker = hentFraSessionStorage(SessionStorageElement.EKSTERN_BRUKER) === 'true';
+const erEksternbruker = erEksternBruker();
 
 export default () => {
     if (erEksternbruker) return eksternbruker;

--- a/src/mocks/me.js
+++ b/src/mocks/me.js
@@ -1,5 +1,20 @@
-export default {
+import { hentFraSessionStorage, SessionStorageElement } from "./sessionstorage";
+
+const eksternbruker = {
+    id: '1234567890',
+    erVeileder: false,
+    erBruker: true,
+};
+
+const veileder = {
     id: 'Z123456',
     erVeileder: true,
     erBruker: false,
+};
+
+const erEksternbruker = hentFraSessionStorage(SessionStorageElement.EKSTERN_BRUKER) === 'true';
+
+export default () => {
+    if (erEksternbruker) return eksternbruker;
+    else return veileder;
 };

--- a/src/mocks/oppfolging.js
+++ b/src/mocks/oppfolging.js
@@ -1,34 +1,34 @@
-import { hentFraSessionStorage, SessionStorageElement } from "./sessionstorage";
+import { erPrivatBruker } from "./sessionstorage";
 
-const erPrivat = hentFraSessionStorage(SessionStorageElement.PRIVAT_BRUKER) === 'true';
+const oppfPerioder = [
+    {
+        aktorId: '1234567988888',
+        veileder: null,
+        startDato: '2018-01-30T10:46:10.971+01:00',
+        sluttDato: '2018-01-31T10:46:10.971+01:00',
+        begrunnelse: null,
+    },
+    {
+        aktorId: '1234567988888',
+        veileder: null,
+        startDato: '2018-01-31T10:46:10.971+01:00',
+        sluttDato: null,
+        begrunnelse: null,
+    },
+];
 
 const oppfolging = {
     fnr: null,
     veilederId: null,
     reservasjonKRR: false,
     manuell: false,
-    underOppfolging: !erPrivat,
+    underOppfolging: !erPrivatBruker(),
     underKvp: false,
     oppfolgingUtgang: null,
     gjeldendeEskaleringsvarsel: null,
     kanStarteOppfolging: false,
     avslutningStatus: null,
-    oppfolgingsPerioder: [
-        {
-            aktorId: '1234567988888',
-            veileder: null,
-            startDato: '2018-01-30T10:46:10.971+01:00',
-            sluttDato: '2018-01-31T10:46:10.971+01:00',
-            begrunnelse: null,
-        },
-        {
-            aktorId: '1234567988888',
-            veileder: null,
-            startDato: '2018-01-31T10:46:10.971+01:00',
-            sluttDato: null,
-            begrunnelse: null,
-        },
-    ],
+    oppfolgingsPerioder: oppfPerioder,
     harSkriveTilgang: true,
     kanReaktiveres: false,
     inaktiveringsdato: '2018-08-31T10:46:10.971+01:00',

--- a/src/mocks/oppfolging.js
+++ b/src/mocks/oppfolging.js
@@ -1,10 +1,13 @@
+import { hentFraSessionStorage, SessionStorageElement } from "./sessionstorage";
+
+const erPrivat = hentFraSessionStorage(SessionStorageElement.PRIVAT_BRUKER) === 'true';
 
 const oppfolging = {
     fnr: null,
     veilederId: null,
     reservasjonKRR: false,
     manuell: false,
-    underOppfolging: true,
+    underOppfolging: !erPrivat,
     underKvp: false,
     oppfolgingUtgang: null,
     gjeldendeEskaleringsvarsel: null,

--- a/src/mocks/sessionstorage.js
+++ b/src/mocks/sessionstorage.js
@@ -1,0 +1,15 @@
+
+export const SessionStorageElement = {
+    PRIVAT_BRUKER: 'privatbruker',
+    EKSTERN_BRUKER: 'eksternbruker',
+
+};
+
+export const settSessionStorage = (key, value) => {
+    window.sessionStorage.setItem(key, value);
+};
+
+export const hentFraSessionStorage = (key) => {
+    return window.sessionStorage.getItem(key);
+};
+

--- a/src/mocks/sessionstorage.js
+++ b/src/mocks/sessionstorage.js
@@ -13,3 +13,10 @@ export const hentFraSessionStorage = (key) => {
     return window.sessionStorage.getItem(key);
 };
 
+export const erEksternBruker = () => {
+    return hentFraSessionStorage(SessionStorageElement.EKSTERN_BRUKER) === 'true';
+};
+
+export const erPrivatBruker = () => {
+    return hentFraSessionStorage(SessionStorageElement.PRIVAT_BRUKER) === 'true';
+};


### PR DESCRIPTION

- Brukergrensesnitt for å velge mellom veileder/eksternbruker og privat modus eller under oppfølging
- Endringer lagres i session storage (default er eksternbruker under oppfølging)

Mangler:
- Styling
- "Ny bruker" innstilling med automatisk oppretta aktiviteter