### PR TITLE
KAIZEN-0: Fjern redux-form i forhåndsorientering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2233,7 +2233,7 @@
     },
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/assertion-error/-/assertion-error-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
@@ -2387,7 +2387,7 @@
     },
     "babel-generator": {
       "version": "6.26.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-generator/-/babel-generator-6.26.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
@@ -2403,13 +2403,13 @@
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://repo.adeo.no/repository/npm-public/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -2567,7 +2567,7 @@
     },
     "babel-helpers": {
       "version": "6.24.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
@@ -2619,7 +2619,7 @@
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
@@ -3358,7 +3358,7 @@
     },
     "babel-register": {
       "version": "6.26.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-register/-/babel-register-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
@@ -3412,13 +3412,13 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://repo.adeo.no/repository/npm-public/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
         "source-map-support": {
           "version": "0.4.18",
-          "resolved": "https://repo.adeo.no/repository/npm-public/source-map-support/-/source-map-support-0.4.18.tgz",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
@@ -3445,7 +3445,7 @@
     },
     "babel-template": {
       "version": "6.26.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-template/-/babel-template-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
@@ -3458,7 +3458,7 @@
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
@@ -3475,7 +3475,7 @@
       "dependencies": {
         "globals": {
           "version": "9.18.0",
-          "resolved": "https://repo.adeo.no/repository/npm-public/globals/-/globals-9.18.0.tgz",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
           "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
           "dev": true
         }
@@ -3483,7 +3483,7 @@
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
@@ -3495,7 +3495,7 @@
       "dependencies": {
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": "https://repo.adeo.no/repository/npm-public/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         }
@@ -4815,7 +4815,7 @@
     },
     "ci-info": {
       "version": "1.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/ci-info/-/ci-info-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true
     },
@@ -5981,7 +5981,7 @@
     },
     "detect-indent": {
       "version": "4.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/detect-indent/-/detect-indent-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
@@ -6487,7 +6487,7 @@
     },
     "eslint": {
       "version": "5.16.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/eslint/-/eslint-5.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
       "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -8039,7 +8039,7 @@
     },
     "home-or-tmp": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
@@ -8675,7 +8675,7 @@
     },
     "is-ci": {
       "version": "1.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-ci/-/is-ci-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
       "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "dev": true,
       "requires": {
@@ -8754,7 +8754,7 @@
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
@@ -8915,7 +8915,7 @@
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
@@ -12370,7 +12370,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -13637,7 +13637,7 @@
     },
     "prettier": {
       "version": "1.5.2",
-      "resolved": "https://repo.adeo.no/repository/npm-public/prettier/-/prettier-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.5.2.tgz",
       "integrity": "sha512-f55mvineQ5yc36cLX4n4RWP6JH6MLcfi5f9MVsjpfBs4MVSG2GYT4v6cukzmvkIOvmNOdCZfDSMY3hQcMcDQbQ==",
       "dev": true
     },
@@ -14274,7 +14274,7 @@
     },
     "react-redux": {
       "version": "5.0.4",
-      "resolved": "https://repo.adeo.no/repository/npm-public/react-redux/-/react-redux-5.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.4.tgz",
       "integrity": "sha1-FWO6utz7JnL1f5zqpDn7Fr+F1Vs=",
       "requires": {
         "create-react-class": "^15.5.1",
@@ -14794,7 +14794,7 @@
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "https://repo.adeo.no/repository/npm-public/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
@@ -16058,7 +16058,7 @@
     },
     "strip-bom": {
       "version": "2.0.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/strip-bom/-/strip-bom-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {

--- a/src/felles-komponenter/skjema/input-v2/checkbox.js
+++ b/src/felles-komponenter/skjema/input-v2/checkbox.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-unused-vars */
+import React, { useState } from 'react';
+import PT from 'prop-types';
+import { Checkbox as NavCheckbox } from 'nav-frontend-skjema';
+
+// pristine isn't used, but we don't want to pass it to input
+function Checkbox({ touched, error, input, pristine, initialValue, ...rest }) {
+    const inputProps = { ...input, ...rest };
+    const [toggel, setToggel] = useState(initialValue === 'true');
+
+    const toggelOnChange = event => {
+        event.target.value = toggel ? 'false' : 'true'; // eslint-disable-line no-param-reassign
+        input.onChange(event);
+        setToggel(!toggel);
+    };
+
+    const feil = error && touched ? { feilmelding: error } : undefined;
+    return (
+        <NavCheckbox
+            {...inputProps}
+            checked={input.value === 'true'}
+            feil={feil}
+            onChange={toggelOnChange}
+        />
+    );
+}
+
+Checkbox.propTypes = {
+    initialValue: PT.string,
+    pristine: PT.bool,
+    touched: PT.bool.isRequired,
+    error: PT.string,
+    input: PT.object.isRequired,
+};
+
+Checkbox.defaultProps = {
+    initialValue: undefined,
+    pristine: undefined,
+    error: undefined,
+};
+
+export default Checkbox;

--- a/src/mocks/oppfoelgingsstatus.js
+++ b/src/mocks/oppfoelgingsstatus.js
@@ -1,7 +1,7 @@
 export default {
     rettighetsgruppe: 'IYT',
     formidlingsgruppe: 'SERV',
-    servicegruppe: 'IVURD',
+    servicegruppe: 'BATT',
     oppfolgingsenhet: {
         navn: 'NAV TEST',
         enhetId: '9999',

--- a/src/moduler/aktivitet/visning/forhandsorientering/forhandsorientering-form.js
+++ b/src/moduler/aktivitet/visning/forhandsorientering/forhandsorientering-form.js
@@ -1,66 +1,90 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PT from 'prop-types';
-import { FormattedMessage, injectIntl } from 'react-intl';
-import { validForm } from 'react-redux-form-validation';
 import { EtikettLiten, Undertittel } from 'nav-frontend-typografi';
 import { Knapp } from 'nav-frontend-knapper';
-import { formValueSelector } from 'redux-form';
 import { HjelpetekstHoyre } from 'nav-frontend-hjelpetekst';
-import Textarea from '../../../../felles-komponenter/skjema/textarea/textarea';
-import {
-    begrensetForhandsorienteringLengde,
-    pakrevdForhandsorienteringLengde,
-} from '../avtalt-container/avtalt-form';
+import useFormstate from '@nutgaard/use-formstate';
 import { selectDialogStatus } from '../../../dialog/dialog-selector';
-import Checkbox from '../../../../felles-komponenter/skjema/input/checkbox';
 import VisibleIfDiv from '../../../../felles-komponenter/utils/visible-if-div';
 import * as AppPT from '../../../../proptypes';
-import visibleIfHOC from '../../../../hocs/visible-if';
 import { sendForhandsorientering } from '../../../dialog/dialog-reducer';
 import { STATUS } from '../../../../ducks/utils';
 import { apneDialog } from '../underelement-for-aktivitet/underelementer-view-reducer';
 import { loggForhandsorienteringTiltak } from '../../../../felles-komponenter/utils/logging';
+import Textarea from '../../../../felles-komponenter/skjema/input-v2/textarea';
+import Checkbox from '../../../../felles-komponenter/skjema/input-v2/checkbox';
 
-function ForhandsorieteringsForm({
-    handleSubmit,
-    dialogStatus,
-    skalSendeForhandsorientering,
-    forhandsorienteringSendt,
-}) {
+const label = (
+    <div className="forhandsorientering-arena-aktivitet">
+        <EtikettLiten className="avtalt-tekst-etikett">
+            Tekst til brukeren
+        </EtikettLiten>
+        <HjelpetekstHoyre>
+            Brukeren får en SMS eller e-post via kontaktinformasjon som brukeren
+            selv har registrert i det offentlige kontaktregisteret. Brukeren får
+            beskjed om en viktig oppgave og det lenkes til dialog. Beskjeden
+            sendes gjennom Altinn etter en halv time. Sender du flere
+            forhåndsorienteringer innen en halv time så blir det kun sendt én
+            SMS eller e-post.
+        </HjelpetekstHoyre>
+    </div>
+);
+
+const initalValue =
+    'Du kan få redusert utbetaling av arbeidsavklaringspenger med én stønadsdag hvis du lar være å ' +
+    '[komme på møtet vi har innkalt deg til [dato]/ møte på … /levere ... innen [dato]] uten rimelig grunn. ' +
+    'Dette går fram av folketrygdloven § 11-9.';
+
+function validate(val) {
+    if (val.trim().length === 0) {
+        return 'Du må fylle ut teksten';
+    }
+    if (val.length > 500) {
+        return 'Du må korte ned teksten til 500 tegn';
+    }
+
+    return null;
+}
+
+const validator = useFormstate({
+    text: validate,
+    checked: () => null,
+});
+
+function ForhandsorieteringsForm(props) {
+    const { visible, dialogStatus, onSubmit } = props;
+
+    const state = validator({
+        text: initalValue,
+        checked: '',
+    });
+
+    if (!visible) {
+        return null;
+    }
+
     const lasterData = dialogStatus !== STATUS.OK;
-    const oppdaterer = dialogStatus === STATUS.RELOADING;
 
     return (
-        <form
-            onSubmit={formdata => {
-                handleSubmit(formdata);
-                forhandsorienteringSendt();
-                loggForhandsorienteringTiltak();
-            }}
-        >
+        <form onSubmit={state.onSubmit(onSubmit)}>
             <Undertittel>
-                <FormattedMessage id="forhandsorientering.arenaaktivitet.tittel" />
+                {'Tiltaket er automatisk merket "Avtalt med NAV"'}
             </Undertittel>
 
             <Checkbox
-                labelId="forhandsorientering.arenaaktivitet.checkbox"
-                name="forhandsorientering"
-                feltNavn="forhandsorienteringArenaAktivitetCheckbox"
+                label="Send forhåndsorientering for §11-9 (AAP)"
                 disabled={lasterData}
+                {...state.fields.checked}
             />
-            <VisibleIfDiv visible={skalSendeForhandsorientering}>
-                <div className="forhandsorientering-arena-aktivitet">
-                    <EtikettLiten className="avtalt-tekst-etikett">
-                        <FormattedMessage id="sett-avltalt-tekst-som-sendes" />
-                    </EtikettLiten>
-                    <HjelpetekstHoyre>
-                        <FormattedMessage id="sett-avtalt-teskt-som-sendes-hjelpetekst" />
-                    </HjelpetekstHoyre>
-                </div>
-                <Textarea feltNavn="avtaltText119" maxLength={500} />
-                <Knapp spinner={oppdaterer} disabled={lasterData}>
-                    <FormattedMessage id="forhandsorientering.arenaaktivitet.bekreft-og-send" />
+            <VisibleIfDiv visible={state.fields.checked.input.value === 'true'}>
+                <Textarea
+                    label={label}
+                    maxLength={500}
+                    {...state.fields.text}
+                />
+                <Knapp spinner={lasterData} autoDisableVedSpinner>
+                    Bekreft og send
                 </Knapp>
             </VisibleIfDiv>
         </form>
@@ -68,9 +92,10 @@ function ForhandsorieteringsForm({
 }
 
 ForhandsorieteringsForm.propTypes = {
+    visible: PT.bool.isRequired,
     valgtAktivitet: AppPT.aktivitet.isRequired,
     dialogStatus: AppPT.status.isRequired,
-    handleSubmit: PT.func.isRequired,
+    onSubmit: PT.func.isRequired,
     forhandsorienteringSendt: PT.func.isRequired,
     skalSendeForhandsorientering: PT.bool,
 };
@@ -79,51 +104,28 @@ ForhandsorieteringsForm.defaultProps = {
     skalSendeForhandsorientering: false,
 };
 
-const formNavn = 'send-forhandsorientering-arena-aktivitet-form';
-const ForhandsorienteringArenaAktivitetForm = validForm({
-    form: formNavn,
-    enableReinitialize: false,
-    validate: {
-        avtaltText119: [
-            begrensetForhandsorienteringLengde,
-            pakrevdForhandsorienteringLengde,
-        ],
-    },
-})(ForhandsorieteringsForm);
-
-const mapStateToProps = (state, props) => {
-    const selector = formValueSelector(formNavn);
+const mapStateToProps = state => {
     return {
-        initialValues: {
-            avtaltText119: props.intl.formatMessage({
-                id: 'sett-forhandsorienterings-tekst-arena-aktivitet',
-            }),
-        },
         dialogStatus: selectDialogStatus(state),
-        skalSendeForhandsorientering: selector(
-            state,
-            'forhandsorienteringArenaAktivitetCheckbox'
-        ),
     };
 };
 
 const mapDispatchToProps = (dispatch, props) => ({
-    onSubmit: formData => {
-        sendForhandsorientering({
+    onSubmit: data => {
+        console.log(data);
+        return sendForhandsorientering({
             aktivitetId: props.valgtAktivitet.id,
-            tekst: formData.avtaltText119,
+            tekst: data.text,
             overskrift: props.valgtAktivitet.tittel,
         })(dispatch).then(() => {
             dispatch(apneDialog());
+            props.forhandsorienteringSendt();
+            loggForhandsorienteringTiltak();
             document.querySelector('.aktivitet-modal').focus();
         });
     },
 });
 
-export default visibleIfHOC(
-    injectIntl(
-        connect(mapStateToProps, mapDispatchToProps)(
-            ForhandsorienteringArenaAktivitetForm
-        )
-    )
+export default connect(mapStateToProps, mapDispatchToProps)(
+    ForhandsorieteringsForm
 );

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/statusadministrasjon.js
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/statusadministrasjon.js
@@ -24,12 +24,13 @@ function Statusadministrasjon({
     valgtAktivitet,
     arenaAktivitet,
     erBruker,
-    erManuellKrrKvpBruker,
+    erManuellKrrKvpBruker, // eslint-disable-line
 }) {
     const { status, type, id } = valgtAktivitet;
 
-    const skalViseForhandsorienteringsKomponent =
-        !erBruker && !erManuellKrrKvpBruker;
+    // TODO add back when used
+    const skalViseForhandsorienteringsKomponent = false;
+    // !erBruker && !erManuellKrrKvpBruker;
 
     const visAdministreresAvVeileder = (
         <div className="aktivitetvisning__underseksjon">

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/statusadministrasjon.js
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/statusadministrasjon.js
@@ -19,21 +19,17 @@ import {
     selectErUnderKvp,
     selectReservasjonKRR,
 } from '../../../oppfolging-status/oppfolging-selector';
-import { selectErBrukerMedIServiceGruppeSTS } from '../../../oppfoelgingsstatus/oppfoelgingsstatus-selector';
 
 function Statusadministrasjon({
     valgtAktivitet,
     arenaAktivitet,
     erBruker,
     erManuellKrrKvpBruker,
-    erSpecieltTilpassetInnsatsBruker,
 }) {
     const { status, type, id } = valgtAktivitet;
 
     const skalViseForhandsorienteringsKomponent =
-        erSpecieltTilpassetInnsatsBruker &&
-        !erBruker &&
-        !erManuellKrrKvpBruker;
+        !erBruker && !erManuellKrrKvpBruker;
 
     const visAdministreresAvVeileder = (
         <div className="aktivitetvisning__underseksjon">
@@ -87,7 +83,6 @@ const mapStateToProps = state => ({
         selectErBrukerManuell(state) ||
         selectErUnderKvp(state) ||
         selectReservasjonKRR(state),
-    erSpecieltTilpassetInnsatsBruker: selectErBrukerMedIServiceGruppeSTS(state),
 });
 
 export default connect(mapStateToProps)(Statusadministrasjon);

--- a/src/moduler/aktivitet/visning/status-oppdatering/oppdater-referat-container.js
+++ b/src/moduler/aktivitet/visning/status-oppdatering/oppdater-referat-container.js
@@ -66,11 +66,12 @@ class OppdaterReferatContainer extends Component {
 OppdaterReferatContainer.defaultProps = {
     className: undefined,
     delelinje: false,
+    erReferatPublisert: false,
 };
 
 OppdaterReferatContainer.propTypes = {
     aktivitet: AppPT.aktivitet.isRequired,
-    erReferatPublisert: PT.bool.isRequired,
+    erReferatPublisert: PT.bool,
     delelinje: PT.bool,
     erVeileder: PT.bool.isRequired,
     underOppfolging: PT.bool.isRequired,


### PR DESCRIPTION
Gjelder bare arena aktiviteter

Vi må vurdere nå om vi skal fjerne koden som omgår oppfoelgingsstatus
Dette er ikke lengre i bruk nå, men vi må høre med produkteier om vi kan bare slutte å bruke statusen for å vise forhåndsorienteringer for arena aktiviteter