### PR TITLE
KAIZEN-0: Ikke vis endre ved fullført/avbrutt

### DIFF
--- a/src/moduler/aktivitet/visning/endre-linje/endre-linje.js
+++ b/src/moduler/aktivitet/visning/endre-linje/endre-linje.js
@@ -6,7 +6,7 @@ import Knappelenke from '../../../../felles-komponenter/utils/knappelenke';
 import styles from './endre-linje.module.less';
 
 function EndreLinje(props) {
-    const { tittel, form, visning, endring, setEndring } = props;
+    const { tittel, form, visning, endring, setEndring, kanEndre } = props;
 
     return (
         <div>
@@ -15,7 +15,7 @@ function EndreLinje(props) {
                     <Normaltekst className={styles.endreTittel}>{tittel}</Normaltekst>
                     <div>{endring ? null : visning}</div>
                 </div>
-                <Knappelenke className={styles.endreKnapp} onClick={() => setEndring(!endring)}>
+                <Knappelenke visible={kanEndre} className={styles.endreKnapp} onClick={() => setEndring(!endring)}>
                     <div className={styles.endreKnappInnhold}>{endring ? 'Avbryt' : 'Endre'}</div>
                     <div className={endring ? styles.endreIndikasjonLukket : styles.endreIndikasjonApen} />
                 </Knappelenke>
@@ -32,7 +32,12 @@ EndreLinje.propTypes = {
     form: PT.node.isRequired,
     visning: PT.node.isRequired,
     endring: PT.bool.isRequired,
-    setEndring: PT.func.isRequired
+    setEndring: PT.func.isRequired,
+    kanEndre: PT.bool
+};
+
+EndreLinje.defaultProps = {
+    kanEndre: true
 };
 
 export default EndreLinje;

--- a/src/moduler/aktivitet/visning/etikett-oppdatering/oppdater-aktivitet-etikett.js
+++ b/src/moduler/aktivitet/visning/etikett-oppdatering/oppdater-aktivitet-etikett.js
@@ -11,6 +11,8 @@ import EndreLinje from '../endre-linje/endre-linje';
 import Underseksjon from '../underseksjon/underseksjon';
 import { selectLasterAktivitetData } from '../../aktivitet-selector';
 import { selectKanEndreAktivitetStatus } from '../../aktivitetliste-selector';
+import { STATUS_FULLFOERT } from '../../../../constant';
+import { STATUS_AVBRUTT } from '../../../../constant';
 
 function OppdaterAktivitetEtikett(props) {
     const { aktivitet, disableEtikettEndringer, lagreEtikett } = props;
@@ -25,6 +27,7 @@ function OppdaterAktivitetEtikett(props) {
         });
 
     const form = <StillingEtikettForm disabled={disableEtikettEndringer} aktivitet={aktivitet} onSubmit={onSubmit} />;
+    const kanEndre = aktivitet.status !== STATUS_FULLFOERT && aktivitet.status !== STATUS_AVBRUTT;
 
     return (
         <Underseksjon>
@@ -34,6 +37,7 @@ function OppdaterAktivitetEtikett(props) {
                 endring={endring}
                 setEndring={setEndring}
                 visning={visning}
+                kanEndre={kanEndre}
             />
         </Underseksjon>
     );

--- a/src/moduler/aktivitet/visning/status-oppdatering/oppdater-aktivitet-status.js
+++ b/src/moduler/aktivitet/visning/status-oppdatering/oppdater-aktivitet-status.js
@@ -11,6 +11,7 @@ import EndreLinje from '../endre-linje/endre-linje';
 import StatusVisning from './status-visning';
 import Underseksjon from '../underseksjon/underseksjon';
 import { selectLasterAktivitetData } from '../../aktivitet-selector';
+import { STATUS_AVBRUTT, STATUS_FULLFOERT } from '../../../../constant';
 
 function OppdaterAktivitetStatus(props) {
     const { aktivitet, disableStatusEndring, lagreStatusEndringer } = props;
@@ -25,6 +26,8 @@ function OppdaterAktivitetStatus(props) {
     const visning = <StatusVisning status={aktivitet.status} />;
     const form = <AktivitetStatusForm disabled={disableStatusEndring} onSubmit={onSubmit} aktivitet={aktivitet} />;
 
+    const kanEndre = aktivitet.status !== STATUS_FULLFOERT && aktivitet.status !== STATUS_AVBRUTT;
+
     return (
         <Underseksjon>
             <EndreLinje
@@ -33,6 +36,7 @@ function OppdaterAktivitetStatus(props) {
                 setEndring={setEndring}
                 visning={visning}
                 form={form}
+                kanEndre={kanEndre}
             />
         </Underseksjon>
     );


### PR DESCRIPTION
På aktivitetskort som ligger i fullført og avbryt
Så skal “endre”-knappen (på status og søknadsprosess-status) skjules (en

Fiksaton