### PR TITLE
Møte: klokkeslett og varighet

### DIFF
--- a/src/moduler/aktivitet/aktivitet-forms/mote/mote-aktivitet-form.js
+++ b/src/moduler/aktivitet/aktivitet-forms/mote/mote-aktivitet-form.js
@@ -5,7 +5,7 @@ import Textarea from '../../../../felles-komponenter/skjema/input/textarea';
 import Input from '../../../../felles-komponenter/skjema/input/input';
 import DatoField from '../../../../felles-komponenter/skjema/datovelger/datovelger';
 import { MOTE_TYPE, OPPMOTE_KANAL } from '../../../../constant';
-import { beregnFraTil, beregnKlokkeslettVarighet, formatterKlokkeslett, formatterVarighet } from '../../aktivitet-util';
+import { beregnFraTil, beregnKlokkeslettVarighet } from '../../aktivitet-util';
 import LagreAktivitet from '../lagre-aktivitet';
 import AktivitetFormHeader from '../aktivitet-form-header';
 import {

--- a/src/moduler/aktivitet/aktivitet-forms/mote/mote-aktivitet-form.js
+++ b/src/moduler/aktivitet/aktivitet-forms/mote/mote-aktivitet-form.js
@@ -23,31 +23,12 @@ import {
 
 import * as AppPT from '../../../../proptypes';
 import FormErrorSummary from '../../../../felles-komponenter/skjema/form-error-summary/form-error-summary';
-import Select from '../../../../felles-komponenter/skjema/input/select';
 import VelgKanal from '../velg-kanal';
 import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 
 function erAvtalt(aktivitet) {
     return aktivitet.avtalt === true;
 }
-
-const tidspunkter = Array.from(new Array(53)).map((noValue, index) => {
-    const minutter = index * 15 + 7 * 60;
-    return (
-        <option key={minutter} value={minutter}>
-            {formatterKlokkeslett(minutter)}
-        </option>
-    );
-});
-
-const varigheter = Array.from(new Array(24)).map((noValue, index) => {
-    const minutter = (index + 1) * 15;
-    return (
-        <option key={minutter} value={minutter}>
-            {formatterVarighet(minutter)}
-        </option>
-    );
-});
 
 const HuskVarsleBruker = props => {
     if (!props.avtalt || props.pristine) {
@@ -83,8 +64,8 @@ function MoteAktivitetForm(props) {
     const initalValue = {
         tittel: maybeAktivitet.tittel || '',
         dato: maybeAktivitet.fraDato || '',
-        klokkeslett: dato.klokkeslett ? dato.klokkeslett.toString() : '',
-        varighet: dato.varighet ? dato.varighet.toString() : '',
+        klokkeslett: dato.klokkeslett ? dato.klokkeslett : '10:00',
+        varighet: dato.varighet ? dato.varighet : '00:45',
         kanal: maybeAktivitet.kanal || OPPMOTE_KANAL,
         adresse: maybeAktivitet.adresse || '',
         beskrivelse: endre ? beskrivelse : defaultBeskrivelse,
@@ -110,13 +91,8 @@ function MoteAktivitetForm(props) {
 
                 <div className="mote-aktivitet-form__velg-mote-klokkeslett">
                     <DatoField label="Dato *" {...state.fields.dato} />
-                    <Select bredde="xs" label="Klokkeslett *" {...state.fields.klokkeslett}>
-                        {tidspunkter}
-                    </Select>
-
-                    <Select bredde="xs" label="Varighet *" {...state.fields.varighet}>
-                        {varigheter}
-                    </Select>
+                    <Input bredde="S" label="Klokkeslett *" {...state.fields.klokkeslett} type="time" step="300" />
+                    <Input bredde="S" label="Varighet *" {...state.fields.varighet} type="time" step="900" />
                 </div>
                 <VelgKanal label="Møteform *" {...state.fields.kanal} />
 

--- a/src/moduler/aktivitet/aktivitet-forms/mote/mote-aktivitet-form.test.js
+++ b/src/moduler/aktivitet/aktivitet-forms/mote/mote-aktivitet-form.test.js
@@ -28,11 +28,9 @@ describe('MoteAktivitetForm', () => {
 
         const error = wrapper.find('Error');
 
-        expect(error.length).toEqual(5);
+        expect(error.length).toEqual(3);
         expect(error.find('[href="#tittel"]').length).toEqual(1);
         expect(error.find('[href="#dato"]').length).toEqual(1);
-        expect(error.find('[href="#klokkeslett"]').length).toEqual(1);
-        expect(error.find('[href="#varighet"]').length).toEqual(1);
         expect(error.find('[href="#adresse"]').length).toEqual(1);
     });
     it('Skal ikke vise feil når obligatoriske felter er oppgitt', () => {
@@ -73,8 +71,8 @@ describe('MoteAktivitetForm', () => {
 
         expect(wrapper.find('Input[label="Tema for møtet *"]').prop('initialValue')).toEqual(aktivitet.tittel);
         expect(wrapper.find('DatoField').prop('initialValue')).toEqual(aktivitet.fraDato);
-        expect(wrapper.find('Select[label="Klokkeslett *"]').prop('initialValue')).toEqual('420');
-        expect(wrapper.find('Select[label="Varighet *"]').prop('initialValue')).toEqual('60');
+        expect(wrapper.find('Input[label="Klokkeslett *"]').prop('initialValue')).toEqual('07:00');
+        expect(wrapper.find('Input[label="Varighet *"]').prop('initialValue')).toEqual('01:00');
         expect(wrapper.find('Input[label="Møtested eller annen praktisk informasjon *"]').prop('initialValue')).toEqual(
             aktivitet.adresse
         );
@@ -112,8 +110,8 @@ describe('MoteAktivitetForm', () => {
         );
         expect(wrapper.find('Input[label="Tema for møtet *"]').prop('disabled')).toBeTruthy();
         expect(wrapper.find('DatoField').prop('disabled')).not.toBeTruthy();
-        expect(wrapper.find('Select[label="Klokkeslett *"]').prop('disabled')).not.toBeTruthy();
-        expect(wrapper.find('Select[label="Varighet *"]').prop('disabled')).not.toBeTruthy();
+        expect(wrapper.find('Input[label="Klokkeslett *"]').prop('disabled')).not.toBeTruthy();
+        expect(wrapper.find('Input[label="Varighet *"]').prop('disabled')).not.toBeTruthy();
         expect(wrapper.find('VelgKanal').prop('disabled')).toBeFalsy();
         expect(
             wrapper.find('Input[label="Møtested eller annen praktisk informasjon *"]').prop('disabled')

--- a/src/moduler/aktivitet/aktivitet-util.test.js
+++ b/src/moduler/aktivitet/aktivitet-util.test.js
@@ -12,11 +12,11 @@ describe('aktivitet-util', () => {
     it('beregnFraTil', () => {
         const fraTil = beregnFraTil({
             dato: '2017-08-01T00:00:00.000+02:00',
-            klokkeslett: 15,
-            varighet: 15
+            klokkeslett: '15:00',
+            varighet: '00:15'
         });
-        expect(fraTil.fraDato).toEqual('2017-07-31T22:15:00.000Z');
-        expect(fraTil.tilDato).toEqual('2017-07-31T22:30:00.000Z');
+        expect(fraTil.fraDato).toEqual('2017-08-01T13:00:00.000Z');
+        expect(fraTil.tilDato).toEqual('2017-08-01T13:15:00.000Z');
 
         expect(beregnFraTil({})).toEqual({});
     });
@@ -26,8 +26,8 @@ describe('aktivitet-util', () => {
             fraDato: '2017-08-01T04:00:00.000+02:00',
             tilDato: '2017-08-01T06:15:00.000+02:00'
         });
-        expect(klokkeslettVarighet.klokkeslett).toEqual(240);
-        expect(klokkeslettVarighet.varighet).toEqual(120 + 15);
+        expect(klokkeslettVarighet.klokkeslett).toEqual('04:00');
+        expect(klokkeslettVarighet.varighet).toEqual('02:15');
         expect(klokkeslettVarighet.dato).toEqual('2017-07-31T22:00:00.000Z');
 
         expect(beregnKlokkeslettVarighet({})).toEqual({});

--- a/src/moduler/aktivitet/aktivitet-util.ts
+++ b/src/moduler/aktivitet/aktivitet-util.ts
@@ -63,8 +63,8 @@ export function erNyEndringIAktivitet(aktivitet: Aktivitet, lestInformasjon: Les
 
 interface MoteTid {
     dato?: string;
-    klokkeslett?: number;
-    varighet?: number;
+    klokkeslett?: string;
+    varighet?: string;
 }
 
 export function beregnKlokkeslettVarighet(aktivitet: Aktivitet): MoteTid {
@@ -73,8 +73,9 @@ export function beregnKlokkeslettVarighet(aktivitet: Aktivitet): MoteTid {
     if (fraDato && tilDato) {
         const fraMoment = moment(fraDato);
         const tilMoment = moment(tilDato);
-        const klokkeslett = fraMoment.minutes() + fraMoment.hours() * 60;
-        const varighet = moment.duration(tilMoment.diff(fraMoment)).asMinutes();
+        const klokkeslett = fraMoment.format('hh:mm');
+        const diff = moment.duration(tilMoment.diff(fraMoment));
+        const varighet = `${('0' + diff.hours()).slice(-2)}:${('0' + diff.minutes()).slice(-2)}`;
         return {
             dato: fraMoment.startOf('day').toISOString(),
             klokkeslett,
@@ -98,15 +99,13 @@ interface FraTil {
 export function beregnFraTil(data: Data): FraTil {
     const { dato, klokkeslett, varighet } = data;
 
-    const numberKlokkeslett = Number(klokkeslett);
-
-    if (dato && varighet && !isNaN(numberKlokkeslett)) {
+    if (dato && klokkeslett && varighet) {
         const fraDato = moment(dato)
             .startOf('day')
-            .minute(numberKlokkeslett)
+            .add(moment.duration(klokkeslett))
             .toISOString();
         const tilDato = moment(fraDato)
-            .add(varighet, 'minutes')
+            .add(moment.duration(varighet))
             .toISOString();
         return {
             fraDato,


### PR DESCRIPTION
Gitt at veileder er inne på en møteaktivitet
så skal jeg se et inputfelt der en kan skrive inn klokkeslettet med kolon i mellom 09:35 (se feks ruter.no for inspirasjon) bruke html-inputtime ?   Foreslår at det er mulig å velge hvert 5. minutt (med html-step-attributten) ELLER gjøre slik google calendar med dropdown+skrivemulighet (se bilde)?
så skal jeg se et inputfelt med validering der jeg kan skrive inn varighet i antall minutter