### PR TITLE
FO-2984: retter feil for brukere som ikke har mal satt

### DIFF
--- a/src/moduler/mal/mal-visning.tsx
+++ b/src/moduler/mal/mal-visning.tsx
@@ -21,7 +21,7 @@ function Malvisning(props: Props) {
 
     const mal = malData && malData.mal;
     const malText: string =
-        historiskVisning && historiskeMal.length === 0 ? 'Det ble ikke skrevet mål i denne perioden' : mal;
+        (historiskVisning && historiskeMal.length === 0) || !mal ? 'Det ble ikke skrevet mål i denne perioden' : mal;
 
     return (
         <div className="aktivitetmal__innhold">

--- a/src/moduler/mal/mal.tsx
+++ b/src/moduler/mal/mal.tsx
@@ -10,11 +10,13 @@ import { Innholdstittel, Undertekst } from 'nav-frontend-typografi';
 import './mal.less';
 import MalHistorikk from './mal-historikk';
 import MalContainer from './mal-container';
+import { selectUnderOppfolging } from '../oppfolging-status/oppfolging-selector';
 
 function Mal() {
     const malStatus = useSelector(selectMalStatus, shallowEqual);
     const malListeStatus = useSelector(selectMalListeStatus, shallowEqual);
     const viserHistoriskPeriode = useSelector(selectViserHistoriskPeriode, shallowEqual);
+    const underOppfolging = useSelector(selectUnderOppfolging, shallowEqual);
 
     const dispatch = useDispatch();
 
@@ -28,7 +30,7 @@ function Mal() {
     return (
         <MalModal>
             <Innholdstittel className="aktivitetmal__header">
-                {viserHistoriskPeriode ? 'Ditt mål fra en tidligere periode' : 'Ditt mål'}
+                {viserHistoriskPeriode || !underOppfolging ? 'Ditt mål fra en tidligere periode' : 'Ditt mål'}
             </Innholdstittel>
             <Undertekst className="aktivitetmal__sub-header" tag="div">
                 Skriv noen ord om hva som er målet ditt slik at vi kan veilede deg bedre.


### PR DESCRIPTION
**Gitt at** bruker ikke er under oppfølging så skal teksten si at målet er satt i en tidligere periode(ref FO-2456)
**Gitt at** bruker ikke skal kunne endre mål og ikke har gjeldende må(privat bruker) så skal appen ikke krasje og det skal vises tekst som sier at det ikke har blitt skrevet mål i denne perioden.