### PR TITLE
FO-2927: Implementerer mocker for feilsituasjoner

### DIFF
--- a/src/mocks/aktivitet.js
+++ b/src/mocks/aktivitet.js
@@ -28,7 +28,7 @@ const testAktiviteter = !visTestAktiviteter()
               arbeidssted: 'Karibien',
               lagtInnAv: 'NAV',
               transaksjonsType: 'AVTALT',
-              erReferatPublisert: false
+              erReferatPublisert: false,
           }),
           wrapAktivitet({
               id: '2',
@@ -51,7 +51,7 @@ const testAktiviteter = !visTestAktiviteter()
               kontaktperson: 'Sabeltann',
               arbeidsgiver: 'Skipet AS',
               arbeidssted: 'Skipet',
-              erReferatPublisert: false
+              erReferatPublisert: false,
           }),
           wrapAktivitet({
               id: '5',
@@ -71,7 +71,7 @@ const testAktiviteter = !visTestAktiviteter()
               transaksjonsType: 'STATUS_ENDRET',
               hensikt: 'Lære meg HTML',
               oppfolging: 'Bli en bedre sjørøver',
-              erReferatPublisert: false
+              erReferatPublisert: false,
           }),
           wrapAktivitet({
               id: '6871',
@@ -109,7 +109,7 @@ const testAktiviteter = !visTestAktiviteter()
               behandlingOppfolging: null,
               kanal: 'TELEFON',
               adresse: 'Ditt nærmeste NAV kontor',
-              erReferatPublisert: false
+              erReferatPublisert: false,
           }),
           wrapAktivitet({
               id: '10',
@@ -146,7 +146,7 @@ const testAktiviteter = !visTestAktiviteter()
               effekt: null,
               behandlingOppfolging: null,
               kanal: 'TELEFON',
-              erReferatPublisert: false
+              erReferatPublisert: false,
           }),
           wrapAktivitet({
               id: '1550',
@@ -185,8 +185,8 @@ const testAktiviteter = !visTestAktiviteter()
               effekt: null,
               behandlingOppfolging: null,
               kanal: null,
-              erReferatPublisert: false
-          })
+              erReferatPublisert: false,
+          }),
       ];
 
 const automatiskeAktiviteter = !visAutomatiskeAktiviteter()
@@ -232,7 +232,7 @@ const automatiskeAktiviteter = !visAutomatiskeAktiviteter()
               forberedelser: null,
               kanal: null,
               referat: null,
-              erReferatPublisert: false
+              erReferatPublisert: false,
           },
           {
               id: '141439',
@@ -274,7 +274,7 @@ const automatiskeAktiviteter = !visAutomatiskeAktiviteter()
               forberedelser: null,
               kanal: null,
               referat: null,
-              erReferatPublisert: false
+              erReferatPublisert: false,
           },
           {
               id: '141440',
@@ -316,8 +316,8 @@ const automatiskeAktiviteter = !visAutomatiskeAktiviteter()
               forberedelser: null,
               kanal: null,
               referat: null,
-              erReferatPublisert: false
-          }
+              erReferatPublisert: false,
+          },
       ];
 
 const aktiviteter = testAktiviteter.concat(automatiskeAktiviteter);
@@ -383,15 +383,15 @@ function wrapAktivitet(aktivitet) {
         forberedelser: valueOrNull(aktivitet.forberedelser),
         kanal: valueOrNull(aktivitet.kanal),
         referat: valueOrNull(aktivitet.referat),
-        erReferatPublisert: valueOrFalse(aktivitet.erReferatPublisert)
+        erReferatPublisert: valueOrFalse(aktivitet.erReferatPublisert),
     };
 }
 
-export function getAktivitet(aktivitetId) {
-    return aktiviteter.filter(akivitet => akivitet.id === aktivitetId)[0];
+export function getAktivitet({ aktivitetId }) {
+    return aktiviteter.filter((akivitet) => akivitet.id === aktivitetId)[0];
 }
 
-export function getAktivitetVersjoner(aktivitetId) {
+export function getAktivitetVersjoner({ aktivitetId }) {
     const aktivitet = getAktivitet(aktivitetId);
     return [
         aktivitet,
@@ -400,12 +400,12 @@ export function getAktivitetVersjoner(aktivitetId) {
             endretDato: '2017-02-26T15:51:44.85+01:00',
             versjon: '2',
             lagtInnAv: 'BRUKER',
-            transaksjonsType: 'OPPRETTET'
-        }
+            transaksjonsType: 'OPPRETTET',
+        },
     ];
 }
 
-export function opprettAktivitet(aktivitet) {
+export function opprettAktivitet(pathParams, body) {
     const newAktivitet = wrapAktivitet({
         id: rndId(),
         opprettetDato: new Date(),
@@ -414,14 +414,14 @@ export function opprettAktivitet(aktivitet) {
         endretAv: null,
         versjon: '1',
         erLestAvBruker: eksternBruker,
-        ...aktivitet
+        ...body,
     });
     aktiviteter.push(newAktivitet);
     return newAktivitet;
 }
 
-export function oppdaterAktivitet(aktivitetId, aktivitet) {
-    const oldAktivitet = aktiviteter.find(akivitet => akivitet.id === aktivitetId);
+export function oppdaterAktivitet({ aktivitetId }, aktivitet) {
+    const oldAktivitet = aktiviteter.find((aktivitet) => aktivitet.id === aktivitetId);
     Object.assign(oldAktivitet, aktivitet);
     oldAktivitet.endretDato = moment().toISOString();
     oldAktivitet.endretAv = bruker;
@@ -429,12 +429,11 @@ export function oppdaterAktivitet(aktivitetId, aktivitet) {
 
     return oldAktivitet;
 }
-
-export function publiserReferat(aktivitetId) {
-    const oldAktivitet = aktiviteter.find(akivitet => akivitet.id === aktivitetId);
+export function publiserReferat({ aktivitetId }) {
+    const oldAktivitet = aktiviteter.find((akivitet) => akivitet.id === aktivitetId);
     return { ...oldAktivitet, erReferatPublisert: true };
 }
 
 export default {
-    aktiviteter
+    aktiviteter,
 };

--- a/src/mocks/demo/demoDashboard.js
+++ b/src/mocks/demo/demoDashboard.js
@@ -17,7 +17,10 @@ import {
     erEskalertBruker,
     oppfFeilet,
     ingenMal,
-    ulesteDialoger
+    ulesteDialoger,
+    dialogFeilet,
+    aktivitetFeilet,
+    arenaFeilet,
 } from './sessionstorage';
 import './demoDashboard.less';
 import Hurtigfilter from './hurtigfilter';
@@ -25,7 +28,7 @@ import { ALL_FEATURES } from '../../felles-komponenter/feature/feature';
 
 const brukertype = {
     ekstern: 'eksternbruker',
-    veileder: 'veilederbruker'
+    veileder: 'veilederbruker',
 };
 
 class DemoDashboard extends React.Component {
@@ -34,7 +37,7 @@ class DemoDashboard extends React.Component {
         window.location.reload();
     };
 
-    endreTilstand = e => {
+    endreTilstand = (e) => {
         const checkbox = e.currentTarget;
         const saveInSessionStorage = Object.values(SessionStorageElement).indexOf(checkbox.id) > -1;
 
@@ -44,7 +47,7 @@ class DemoDashboard extends React.Component {
         }
     };
 
-    endreBrukerType = e => {
+    endreBrukerType = (e) => {
         const element = e.currentTarget;
         const erVeileder = element.id === brukertype.veileder;
 
@@ -69,13 +72,13 @@ class DemoDashboard extends React.Component {
                         {
                             label: 'Veileder',
                             id: brukertype.veileder,
-                            value: brukertype.veileder
+                            value: brukertype.veileder,
                         },
                         {
                             label: 'Eksternbruker',
                             id: brukertype.ekstern,
-                            value: brukertype.ekstern
-                        }
+                            value: brukertype.ekstern,
+                        },
                     ]}
                     checked={this.getBrukerType()}
                     onChange={this.endreBrukerType}
@@ -86,38 +89,33 @@ class DemoDashboard extends React.Component {
                         {
                             label: 'Ikke under oppfølging',
                             id: SessionStorageElement.PRIVAT_BRUKER,
-                            checked: erPrivatBruker()
+                            checked: erPrivatBruker(),
                         },
                         {
                             label: 'Manuell',
                             id: SessionStorageElement.MANUELL_BRUKER,
-                            checked: erManuellBruker()
+                            checked: erManuellBruker(),
                         },
                         {
                             label: 'KRR',
                             id: SessionStorageElement.KRR_BRUKER,
-                            checked: erKRRBruker()
+                            checked: erKRRBruker(),
                         },
                         {
                             label: 'Ingen oppfølgingsperioder',
                             id: SessionStorageElement.INGEN_OPPF_PERIODER,
-                            checked: ingenOppfPerioder()
+                            checked: ingenOppfPerioder(),
                         },
                         {
                             label: 'Eskaleringsvarsel',
                             id: SessionStorageElement.ESKALERT_BRUKER,
-                            checked: erEskalertBruker()
-                        },
-                        {
-                            label: 'Oppfølging feiler',
-                            id: SessionStorageElement.OPPF_FEILET,
-                            checked: oppfFeilet()
+                            checked: erEskalertBruker(),
                         },
                         {
                             label: 'Uleste dialoger',
                             id: SessionStorageElement.ULESTE_DIALOGER,
-                            checked: ulesteDialoger()
-                        }
+                            checked: ulesteDialoger(),
+                        },
                     ]}
                     onChange={this.endreTilstand}
                 />
@@ -127,29 +125,29 @@ class DemoDashboard extends React.Component {
                         {
                             label: 'Automatiske aktiviteter',
                             id: SessionStorageElement.AUTOMATISKE_AKTIVITETER,
-                            checked: visAutomatiskeAktiviteter()
+                            checked: visAutomatiskeAktiviteter(),
                         },
                         {
                             label: 'Arenaaktiviteter',
                             id: SessionStorageElement.ARENA_AKTIVITETER,
-                            checked: visArenaAktiviteter()
+                            checked: visArenaAktiviteter(),
                         },
                         {
                             label: 'Testaktiviteter',
                             id: SessionStorageElement.TEST_AKTIVITETER,
-                            checked: visTestAktiviteter()
-                        }
+                            checked: visTestAktiviteter(),
+                        },
                     ]}
                     onChange={this.endreTilstand}
                 />
                 <CheckboksPanelGruppe
                     legend="Feature togles"
-                    checkboxes={ALL_FEATURES.map(name => {
+                    checkboxes={ALL_FEATURES.map((name) => {
                         return {
                             label: name,
                             id: name,
                             value: name,
-                            checked: fetureStatus(name)
+                            checked: fetureStatus(name),
                         };
                     })}
                     onChange={this.setFeature}
@@ -160,8 +158,34 @@ class DemoDashboard extends React.Component {
                         {
                             label: 'Ingen mål',
                             id: SessionStorageElement.INGEN_MAL,
-                            checked: ingenMal()
-                        }
+                            checked: ingenMal(),
+                        },
+                    ]}
+                    onChange={this.endreTilstand}
+                />
+                <CheckboksPanelGruppe
+                    legend="Feiltilstander"
+                    checkboxes={[
+                        {
+                            label: 'Oppfølging feiler',
+                            id: SessionStorageElement.OPPF_FEILET,
+                            checked: oppfFeilet(),
+                        },
+                        {
+                            label: 'Dialog feiler',
+                            id: SessionStorageElement.DIALOG_FEILET,
+                            checked: dialogFeilet(),
+                        },
+                        {
+                            label: 'Aktivitet feiler',
+                            id: SessionStorageElement.AKTIVITET_FEILET,
+                            checked: aktivitetFeilet(),
+                        },
+                        {
+                            label: 'Arena feiler',
+                            id: SessionStorageElement.ARENA_FEILET,
+                            checked: arenaFeilet(),
+                        },
                     ]}
                     onChange={this.endreTilstand}
                 />

--- a/src/mocks/demo/sessionstorage.js
+++ b/src/mocks/demo/sessionstorage.js
@@ -4,6 +4,9 @@ export const SessionStorageElement = {
     KRR_BRUKER: 'krrbruker',
     ESKALERT_BRUKER: 'eskalertbruker',
     OPPF_FEILET: 'oppffeilet',
+    DIALOG_FEILET: 'dialogfeilet',
+    AKTIVITET_FEILET: 'aktivitetfeilet',
+    ARENA_FEILET: 'arenafeilet',
     EKSTERN_BRUKER: 'eksternbruker',
     INGEN_OPPF_PERIODER: 'ingen_oppf_perioder',
     AUTOMATISKE_AKTIVITETER: 'automatiske_aktiviteter',
@@ -11,22 +14,22 @@ export const SessionStorageElement = {
     ARENA_AKTIVITETER: 'arena_aktiviteter',
     TEST_DIALOGER: 'test_dialoger',
     INGEN_MAL: 'ingen_mal',
-    ULESTE_DIALOGER: 'uleste_dialoger'
+    ULESTE_DIALOGER: 'uleste_dialoger',
 };
 
 export const settSessionStorage = (key, value) => {
     window.localStorage.setItem(key, value);
 };
 
-export const hentFraSessionStorage = key => {
+export const hentFraSessionStorage = (key) => {
     return window.localStorage.getItem(key);
 };
 
-const erSatt = sessionStorageElement => {
+const erSatt = (sessionStorageElement) => {
     return hentFraSessionStorage(sessionStorageElement) === 'true';
 };
 
-const erSkrudAv = sessionStorageElement => hentFraSessionStorage(sessionStorageElement) === 'false';
+const erSkrudAv = (sessionStorageElement) => hentFraSessionStorage(sessionStorageElement) === 'false';
 
 export const erEksternBruker = () => erSatt(SessionStorageElement.EKSTERN_BRUKER);
 
@@ -50,10 +53,16 @@ export const visDialoger = () => erSatt(SessionStorageElement.TEST_DIALOGER);
 
 export const oppfFeilet = () => erSatt(SessionStorageElement.OPPF_FEILET);
 
+export const dialogFeilet = () => erSatt(SessionStorageElement.DIALOG_FEILET);
+
+export const aktivitetFeilet = () => erSatt(SessionStorageElement.AKTIVITET_FEILET);
+
+export const arenaFeilet = () => erSatt(SessionStorageElement.ARENA_FEILET);
+
 export const ulesteDialoger = () => erSatt(SessionStorageElement.ULESTE_DIALOGER);
 
 const fetureprefix = 'mock_feature__';
 export const setFeatureTogle = (name, value) => settSessionStorage(fetureprefix + name, value);
-export const fetureStatus = name => hentFraSessionStorage(fetureprefix + name) !== 'false';
+export const fetureStatus = (name) => hentFraSessionStorage(fetureprefix + name) !== 'false';
 
 export const ingenMal = () => erSatt(SessionStorageElement.INGEN_MAL);

--- a/src/mocks/failOrGetResponse.tsx
+++ b/src/mocks/failOrGetResponse.tsx
@@ -1,0 +1,27 @@
+import { HandlerResponseElement, MockContext, MockHandler, ResponseData } from 'yet-another-fetch-mock';
+
+export const internalServerError = (ctx: MockContext): Array<HandlerResponseElement> => [
+    ctx.status(500),
+    ctx.statusText('Internal server error'),
+    ctx.json({
+        id: '9170c6534ed5eca272d527cd30c6a458',
+        type: 'UKJENT',
+        detaljer: {
+            detaljertType: 'javax.ws.rs.InternalServerErrorException',
+            feilMelding: 'HTTP 500 Internal Server Error',
+            stackTrace: 'javax.ws.rs.InternalServerErrorException: HTTP 500 Internal Server Error\r\n\t',
+        },
+    }),
+];
+
+export function failOrGetResponse(
+    failFn: () => boolean,
+    successFn: (params: string, body: object) => object
+): MockHandler {
+    return (req, res, ctx): Promise<ResponseData> => {
+        if (failFn()) {
+            return res(...internalServerError(ctx));
+        }
+        return res(ctx.json(successFn(req.pathParams, req.body)));
+    };
+}

--- a/src/mocks/oppfolging.js
+++ b/src/mocks/oppfolging.js
@@ -72,10 +72,10 @@ const oppfolging = {
     inaktiveringsdato: '2018-08-31T10:46:10.971+01:00',
 };
 
-export default function (queryParams, changeFn = (ob) => ob) {
+export default function (queryParams) {
     const { fnr } = queryParams;
     oppfolging.fnr = fnr;
-    return changeFn(oppfolging);
+    return oppfolging;
 }
 
 export function startEskalering(update) {


### PR DESCRIPTION
Gjør det mulig å teste situasjoner hvor backendkall feiler.
Alle kall mot samme backend bruker samme innstilling i demomocken(unntatt arenaaktiviteter som er separat fordi dette er et eget scenario i brukerhistorien)
Man kan teste at GET på aktivitet feiler ved å krysse av for "aktivitet feiler" og gå direkte til url for en aktivitet.
Enn så lenge så ser jeg ikke behov for å trenge å finjustere mer hvilke kall som feiler men gi beskjed om du mener noe annet