### PR TITLE
Full bredde på felt 'mål for behandlingen' på medisinsk behandling

### DIFF
--- a/src/moduler/aktivitet/visning/detaljer/behandlings-detaljer.js
+++ b/src/moduler/aktivitet/visning/detaljer/behandlings-detaljer.js
@@ -26,11 +26,13 @@ const BehandlingsDetaljer = ({ aktivitet }) => (
                 key="effekt"
                 tittel={<FormattedMessage id="aktivitetdetaljer.effekt-label" />}
                 innhold={aktivitet.effekt}
+                fullbredde={true}
             />
             <Informasjonsfelt
                 key="behandlingOppfolging"
                 tittel={<FormattedMessage id="aktivitetdetaljer.behandling-oppfolging-label" />}
                 innhold={aktivitet.behandlingOppfolging}
+                fullbredde={true}
             />
             <Beskrivelse aktivitet={aktivitet} />
         </div>

--- a/src/moduler/aktivitet/visning/detaljer/behandlings-detaljer.js
+++ b/src/moduler/aktivitet/visning/detaljer/behandlings-detaljer.js
@@ -26,13 +26,13 @@ const BehandlingsDetaljer = ({ aktivitet }) => (
                 key="effekt"
                 tittel={<FormattedMessage id="aktivitetdetaljer.effekt-label" />}
                 innhold={aktivitet.effekt}
-                fullbredde={true}
+                fullbredde
             />
             <Informasjonsfelt
                 key="behandlingOppfolging"
                 tittel={<FormattedMessage id="aktivitetdetaljer.behandling-oppfolging-label" />}
                 innhold={aktivitet.behandlingOppfolging}
-                fullbredde={true}
+                fullbredde
             />
             <Beskrivelse aktivitet={aktivitet} />
         </div>


### PR DESCRIPTION
Ikke sikker på om løsning er korrekt. Ser ikke helt hvordan styling og css klasser brukes for å styre visning, så løsningen er en ganske eksplisitt fix direkte på BehandlingsDetaljer komponenten.