### PR TITLE
Småfiks på forhåndsorienteringsflyten

### DIFF
--- a/src/felles-komponenter/ekspanderbar-linje/EkspanderbarLinjeBase.module.less
+++ b/src/felles-komponenter/ekspanderbar-linje/EkspanderbarLinjeBase.module.less
@@ -43,10 +43,10 @@
 }
 
 .endreForm {
-    padding: 1rem 1rem;
+    padding: 0.2rem 1rem 1rem 1rem;
 
     @media (min-width: @screen-md-min) {
-        padding: 1rem 2rem;
+        padding: 0.2rem 2rem 1rem 2rem;
     }
 }
 

--- a/src/moduler/aktivitet/visning/avtalt-container/AvtaltContainerNy.tsx
+++ b/src/moduler/aktivitet/visning/avtalt-container/AvtaltContainerNy.tsx
@@ -64,10 +64,22 @@ const AvtaltContainerNy = (props: Props) => {
         );
     }
     if (skalViseSattTilAvtalt) {
-        return <SattTilAvtaltVisning forhaandsorienteringstype={forhandsorienteringType} aktivitet={aktivitet} />;
+        return (
+            <SattTilAvtaltVisning
+                forhaandsorienteringstype={forhandsorienteringType}
+                aktivitet={aktivitet}
+                erArenaAktivitet={erArenaAktivitet}
+            />
+        );
     }
 
-    return <ForhaandsorienteringsVisningsLinje aktivitet={aktivitet} erBruker={erBruker} />;
+    return (
+        <ForhaandsorienteringsVisningsLinje
+            aktivitet={aktivitet}
+            erBruker={erBruker}
+            erArenaAktivitet={erArenaAktivitet}
+        />
+    );
 };
 
 export default AvtaltContainerNy;

--- a/src/moduler/aktivitet/visning/avtalt-container/ForhaandsorienteringsVisningsLinje.tsx
+++ b/src/moduler/aktivitet/visning/avtalt-container/ForhaandsorienteringsVisningsLinje.tsx
@@ -7,14 +7,16 @@ import Forhaandsorienteringsvisning from '../hjelpekomponenter/forhaandsorienter
 interface Props {
     aktivitet: Aktivitet;
     erBruker: boolean;
+    erArenaAktivitet: boolean;
 }
 
-const ForhaandsorienteringsVisningsLinje = ({ aktivitet, erBruker }: Props) => (
+const ForhaandsorienteringsVisningsLinje = ({ aktivitet, erBruker, erArenaAktivitet }: Props) => (
     <>
         <DeleLinje />
         <Forhaandsorienteringsvisning
             aktivitet={aktivitet}
             startAapen={erBruker && !aktivitet.forhaandsorientering?.lest}
+            erArenaAktivitet={erArenaAktivitet}
         />
         <DeleLinje />
     </>

--- a/src/moduler/aktivitet/visning/avtalt-container/SattTilAvtaltVisning.tsx
+++ b/src/moduler/aktivitet/visning/avtalt-container/SattTilAvtaltVisning.tsx
@@ -9,10 +9,11 @@ import SattTilAvtaltInfotekst from './SattTilAvtaltInfotekst';
 interface Props {
     forhaandsorienteringstype: ForhaandsorienteringType;
     aktivitet: Aktivitet;
+    erArenaAktivitet: boolean;
 }
 
 const SattTilAvtaltVisning = (props: Props) => {
-    const { aktivitet, forhaandsorienteringstype } = props;
+    const { aktivitet, forhaandsorienteringstype, erArenaAktivitet } = props;
 
     const mindreEnnSyvDagerTil = !erMerEnnSyvDagerTil(aktivitet.tilDato);
 
@@ -27,7 +28,7 @@ const SattTilAvtaltVisning = (props: Props) => {
                 mindreEnnSyvDagerTil={mindreEnnSyvDagerTil}
                 forhaandsorienteringstype={forhaandsorienteringstype}
             />
-            <Forhaandsorienteringsvisning aktivitet={aktivitet} startAapen />
+            <Forhaandsorienteringsvisning aktivitet={aktivitet} erArenaAktivitet={erArenaAktivitet} startAapen />
             <DeleLinje />
         </>
     );

--- a/src/moduler/aktivitet/visning/avtalt-container/aktivitet/AvtaltForm.module.less
+++ b/src/moduler/aktivitet/visning/avtalt-container/aktivitet/AvtaltForm.module.less
@@ -1,6 +1,5 @@
 .checkbox {
     display: flex;
-    padding-bottom: 5px;
     .checkboxNoSpace {
         margin-bottom: 0 !important;
     }

--- a/src/moduler/aktivitet/visning/endre-linje/endre-linje.module.less
+++ b/src/moduler/aktivitet/visning/endre-linje/endre-linje.module.less
@@ -55,10 +55,10 @@
 }
 
 .endreForm {
-    padding: 1rem 1rem;
+    padding: 0.2rem 1rem 1rem 1rem;
 
     @media (min-width: @screen-md-min) {
-        padding: 1rem 2rem;
+        padding: 0.2rem 2rem 1rem 2rem;
     }
 }
 

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/forhaandsorientering/Forhaandsorienteringsvisning.tsx
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/forhaandsorientering/Forhaandsorienteringsvisning.tsx
@@ -2,10 +2,13 @@ import { Normaltekst } from 'nav-frontend-typografi';
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { STATUS } from '../../../../../api/utils';
 import { Aktivitet } from '../../../../../datatypes/aktivitetTypes';
 import EkspanderbarLinjeBase from '../../../../../felles-komponenter/ekspanderbar-linje/EkspanderbarLinjeBase';
 import { selectErBruker } from '../../../../identitet/identitet-selector';
 import { markerForhaandsorienteringSomLest } from '../../../aktivitet-actions';
+import { selectAktivitetStatus } from '../../../aktivitet-selector';
+import { selectArenaAktivitetStatus } from '../../../arena-aktivitet-selector';
 import { markerForhaandsorienteringSomLestArenaAktivitet } from '../../../arena-aktiviteter-reducer';
 import styles from './Forhaandsorienteringsvisning.module.less';
 import LestDatoVisning from './LestDatoVisning';
@@ -14,11 +17,12 @@ import Tittel from './Tittel';
 
 interface Props {
     aktivitet: Aktivitet;
+    erArenaAktivitet: boolean;
     startAapen?: boolean;
 }
 
 const Forhaandsorienteringsvisning = (props: Props) => {
-    const { aktivitet, startAapen = false } = props;
+    const { aktivitet, erArenaAktivitet, startAapen = false } = props;
 
     const forhaandsorienteringTekst = aktivitet.forhaandsorientering?.tekst;
     const forhaandsorienteringLestDato = aktivitet.forhaandsorientering?.lest;
@@ -26,6 +30,9 @@ const Forhaandsorienteringsvisning = (props: Props) => {
     const erLest = !!forhaandsorienteringLestDato;
 
     const erBruker = useSelector(selectErBruker);
+    const arenaAktivitetStatus = useSelector(selectArenaAktivitetStatus);
+    const aktivitetStatus = useSelector(selectAktivitetStatus);
+
     const dispatch = useDispatch();
 
     const kanMarkeresSomLest = !erLest && erBruker;
@@ -37,7 +44,7 @@ const Forhaandsorienteringsvisning = (props: Props) => {
     }
 
     const onMarkerSomLest = () => {
-        if (aktivitet.arenaAktivitet) {
+        if (erArenaAktivitet) {
             dispatch(markerForhaandsorienteringSomLestArenaAktivitet(aktivitet));
         } else {
             dispatch(markerForhaandsorienteringSomLest(aktivitet));
@@ -51,6 +58,10 @@ const Forhaandsorienteringsvisning = (props: Props) => {
 
     const onClickToggle = () => setErEkspandert((ekspandert) => !ekspandert);
 
+    const lasterDataArena = arenaAktivitetStatus !== STATUS.OK;
+    const lasterDataAktivitet = aktivitetStatus !== STATUS.OK;
+    const lasterData = erArenaAktivitet ? lasterDataArena : lasterDataAktivitet;
+
     return (
         <EkspanderbarLinjeBase
             tittel={<Tittel kanMarkeresSomLest={kanMarkeresSomLest} />}
@@ -62,7 +73,7 @@ const Forhaandsorienteringsvisning = (props: Props) => {
         >
             <Normaltekst className={styles.forhaandsorienteringTekst}>{forhaandsorienteringTekst}</Normaltekst>
             <LestDatoVisning hidden={!erLest} lestDato={forhaandsorienteringLestDato} />
-            <LestKnapp hidden={!kanMarkeresSomLest} onClick={onClickLestKnapp} />
+            <LestKnapp hidden={!kanMarkeresSomLest} onClick={onClickLestKnapp} lasterData={lasterData} />
         </EkspanderbarLinjeBase>
     );
 };

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/forhaandsorientering/LestDatoVisning.module.less
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/forhaandsorientering/LestDatoVisning.module.less
@@ -2,5 +2,5 @@
 
 .lestDato {
     color: @navGra60;
-    margin-top: 1rem;
+    margin-top: 1rem !important;
 }

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/forhaandsorientering/LestDatoVisning.tsx
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/forhaandsorientering/LestDatoVisning.tsx
@@ -1,4 +1,4 @@
-import { Normaltekst } from 'nav-frontend-typografi';
+import { Undertekst } from 'nav-frontend-typografi';
 import React from 'react';
 
 import { formaterDatoKortManed } from '../../../../../utils';
@@ -16,7 +16,7 @@ const LestDatoVisning = (props: Props) => {
         return null;
     }
 
-    return <Normaltekst className={styles.lestDato}>Lest {formaterDatoKortManed(lestDato)}</Normaltekst>;
+    return <Undertekst className={styles.lestDato}>Lest {formaterDatoKortManed(lestDato)}</Undertekst>;
 };
 
 export default LestDatoVisning;

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/forhaandsorientering/LestKnapp.tsx
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/forhaandsorientering/LestKnapp.tsx
@@ -5,18 +5,19 @@ import styles from './LestKnapp.module.less';
 
 interface Props {
     hidden: boolean;
+    lasterData: boolean;
     onClick(): void;
 }
 
 const LestKnapp = (props: Props) => {
-    const { hidden, onClick } = props;
+    const { hidden, lasterData, onClick } = props;
 
     if (hidden) {
         return null;
     }
 
     return (
-        <Knapp onClick={onClick} className={styles.lestKnapp} mini>
+        <Knapp onClick={onClick} className={styles.lestKnapp} spinner={lasterData} autoDisableVedSpinner mini>
             Ok, jeg har lest beskjeden
         </Knapp>
     );


### PR DESCRIPTION
Småting fikset sammen med Linn:
- Småfiks med luft
- Fikse en stillekkasje
- Fiks av typen tekst brukt på lestdatoen
- Legge til spinner på knapp etter at man har trykket på lest-knappen
- Bruke samme konstant som i container for å sjekke om det er en arenaaktivitet