### PR TITLE
Migrere use-formstate til ny versjon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@navikt/fnrvalidator": "^1.1.3",
         "@navikt/navspa": "1.1.1",
-        "@nutgaard/use-formstate": "^2.2.1",
+        "@nutgaard/use-formstate": "^3.0.1",
         "babel-polyfill": "^6.26.0",
         "classnames": "^2.2.6",
         "date-fns": "^2.16.1",
@@ -4393,15 +4393,18 @@
       }
     },
     "node_modules/@nutgaard/use-formstate": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@nutgaard/use-formstate/-/use-formstate-2.2.1.tgz",
-      "integrity": "sha512-Hxt4u7PYkpMFAr363dQaS2/as+kD1FEOjG5JbQbKlfNS1/aiouHVHWtE3Vbl72viTJv5xMP3lcoLCRRrrOX4IQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nutgaard/use-formstate/-/use-formstate-3.0.1.tgz",
+      "integrity": "sha512-bmTsroBEmytau6dMuPnFbySPDrHAtSs+Tye0ZFd4uG/N7dwOiTqnV8mgqhWHMLlhkU/xL0b4dR0tWfonkB/fRw==",
       "dependencies": {
-        "immer": "^3.1.3",
-        "use-immer": "^0.3.3"
+        "immer": "^9.0.1",
+        "use-immer": "^0.5.1"
       },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -12848,9 +12851,13 @@
       }
     },
     "node_modules/immer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-3.3.0.tgz",
-      "integrity": "sha512-vlWRjnZqoTHuEjadquVHK3GxsXe1gNoATffLEA8Qbrdd++Xb+wHEFiWtwAKTscMBoi1AsvEMXhYRzAXA8Ex9FQ=="
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.2.tgz",
+      "integrity": "sha512-mkcmzLtIfSp40vAqteRr1MbWNSoI7JE+/PB36FNPoSfJ9RQRmNKuTYCjKkyXyuq3Dgn07HuJBrwJd4ZSk2yUbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
     },
     "node_modules/import-cwd": {
       "version": "2.1.0",
@@ -25295,9 +25302,13 @@
       }
     },
     "node_modules/use-immer": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.3.5.tgz",
-      "integrity": "sha512-0CNaJ/CtnF8/OmM4NBG7R0rhWMMQtgXPmWbakv8CK5z8dXeMaBYValFDXpkjBnToknjKJZuEPcoUZYd0rnQL2Q=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.5.1.tgz",
+      "integrity": "sha512-Orb7PokM+jiLQfA1oJ3B3P7Guq0c2IxUHHmBpLeEMnJiz4ZOMlj9mkqq6D7iXJsnurRX0EOB134annf3RjEWHw==",
+      "peerDependencies": {
+        "immer": ">=2.0.0",
+        "react": "^16.8.0 || ^17.0.1"
+      }
     },
     "node_modules/util": {
       "version": "0.11.1",
@@ -25597,6 +25608,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -26037,6 +26049,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -31213,12 +31226,12 @@
       }
     },
     "@nutgaard/use-formstate": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@nutgaard/use-formstate/-/use-formstate-2.2.1.tgz",
-      "integrity": "sha512-Hxt4u7PYkpMFAr363dQaS2/as+kD1FEOjG5JbQbKlfNS1/aiouHVHWtE3Vbl72viTJv5xMP3lcoLCRRrrOX4IQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nutgaard/use-formstate/-/use-formstate-3.0.1.tgz",
+      "integrity": "sha512-bmTsroBEmytau6dMuPnFbySPDrHAtSs+Tye0ZFd4uG/N7dwOiTqnV8mgqhWHMLlhkU/xL0b4dR0tWfonkB/fRw==",
       "requires": {
-        "immer": "^3.1.3",
-        "use-immer": "^0.3.3"
+        "immer": "^9.0.1",
+        "use-immer": "^0.5.1"
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
@@ -38429,9 +38442,9 @@
       "optional": true
     },
     "immer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-3.3.0.tgz",
-      "integrity": "sha512-vlWRjnZqoTHuEjadquVHK3GxsXe1gNoATffLEA8Qbrdd++Xb+wHEFiWtwAKTscMBoi1AsvEMXhYRzAXA8Ex9FQ=="
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.2.tgz",
+      "integrity": "sha512-mkcmzLtIfSp40vAqteRr1MbWNSoI7JE+/PB36FNPoSfJ9RQRmNKuTYCjKkyXyuq3Dgn07HuJBrwJd4ZSk2yUbw=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -48728,9 +48741,10 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "use-immer": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.3.5.tgz",
-      "integrity": "sha512-0CNaJ/CtnF8/OmM4NBG7R0rhWMMQtgXPmWbakv8CK5z8dXeMaBYValFDXpkjBnToknjKJZuEPcoUZYd0rnQL2Q=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.5.1.tgz",
+      "integrity": "sha512-Orb7PokM+jiLQfA1oJ3B3P7Guq0c2IxUHHmBpLeEMnJiz4ZOMlj9mkqq6D7iXJsnurRX0EOB134annf3RjEWHw==",
+      "requires": {}
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@navikt/fnrvalidator": "^1.1.3",
     "@navikt/navspa": "1.1.1",
-    "@nutgaard/use-formstate": "^2.2.1",
+    "@nutgaard/use-formstate": "^3.0.1",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.6",
     "date-fns": "^2.16.1",

--- a/src/felles-komponenter/skjema/datovelger/utils.ts
+++ b/src/felles-komponenter/skjema/datovelger/utils.ts
@@ -4,7 +4,7 @@ import { erGyldigISODato, toDatePrettyPrint } from '../../../utils';
 
 export const validerDato = (value: string | null, tidligsteFom?: string, senesteTom?: string) => {
     if (!value || value.trim().length === 0) {
-        return null;
+        return undefined;
     }
 
     if (!erGyldigISODato(value)) {
@@ -26,5 +26,5 @@ export const validerDato = (value: string | null, tidligsteFom?: string, seneste
         return `Datoen må være innenfor perioden ${prettyFra}-${prettyTil}`;
     }
 
-    return null;
+    return undefined;
 };

--- a/src/felles-komponenter/skjema/datovelger/utils.ts
+++ b/src/felles-komponenter/skjema/datovelger/utils.ts
@@ -4,7 +4,7 @@ import { erGyldigISODato, toDatePrettyPrint } from '../../../utils';
 
 export const validerDato = (value: string | null, tidligsteFom?: string, senesteTom?: string) => {
     if (!value || value.trim().length === 0) {
-        return undefined;
+        return;
     }
 
     if (!erGyldigISODato(value)) {
@@ -25,6 +25,4 @@ export const validerDato = (value: string | null, tidligsteFom?: string, seneste
 
         return `Datoen må være innenfor perioden ${prettyFra}-${prettyTil}`;
     }
-
-    return undefined;
 };

--- a/src/felles-komponenter/skjema/input/Checkbox.tsx
+++ b/src/felles-komponenter/skjema/input/Checkbox.tsx
@@ -9,7 +9,7 @@ interface Props {
     touched: boolean;
     error?: string;
     input: FieldStateInput;
-    setValue: (value: string) => void;
+    setValue?: (value: string) => void;
 }
 // pristine isn't used, but we don't want to pass it to input
 const Checkbox = (props: Props & CheckboxProps) => {

--- a/src/felles-komponenter/skjema/input/Checkbox.tsx
+++ b/src/felles-komponenter/skjema/input/Checkbox.tsx
@@ -9,10 +9,11 @@ interface Props {
     touched: boolean;
     error?: string;
     input: FieldStateInput;
+    setValue: (value: string) => void;
 }
 // pristine isn't used, but we don't want to pass it to input
 const Checkbox = (props: Props & CheckboxProps) => {
-    const { touched, error, input, pristine, initialValue, ...rest } = props;
+    const { touched, error, input, pristine, initialValue, setValue, ...rest } = props;
 
     const inputProps = { ...input, ...rest };
     const [toggel, setToggel] = useState(initialValue === 'true');

--- a/src/felles-komponenter/skjema/input/Input.tsx
+++ b/src/felles-komponenter/skjema/input/Input.tsx
@@ -11,11 +11,12 @@ interface Props {
     input: FieldStateInput;
     pristine?: boolean;
     initialValue?: string;
+    setValue: (value: string) => void;
 }
 
 // pristine and initialValue isn't used, but we don't want to pass it to input
 const Input = (props: Props & InputProps) => {
-    const { touched, error, input, pristine, initialValue, ...rest } = props;
+    const { touched, error, input, pristine, initialValue, setValue, ...rest } = props;
     const feil = error && touched ? error : undefined;
     const inputProps = { ...input, ...rest };
     return <NavInput {...inputProps} feil={feil} required />;

--- a/src/felles-komponenter/skjema/input/Input.tsx
+++ b/src/felles-komponenter/skjema/input/Input.tsx
@@ -11,7 +11,7 @@ interface Props {
     input: FieldStateInput;
     pristine?: boolean;
     initialValue?: string;
-    setValue: (value: string) => void;
+    setValue?: (value: string) => void;
 }
 
 // pristine and initialValue isn't used, but we don't want to pass it to input

--- a/src/felles-komponenter/skjema/input/Radio.tsx
+++ b/src/felles-komponenter/skjema/input/Radio.tsx
@@ -15,11 +15,12 @@ interface RadioProps {
     touched: boolean;
     error?: string;
     input: FieldStateInput;
+    setValue: (value: string) => void;
 }
 
 // pristine and initialValue isn't used, but we don't want to pass it to input
 const Radio = (props: RadioProps) => {
-    const { value, touched, error, input, pristine, initialValue, ...rest } = props;
+    const { value, touched, error, input, pristine, initialValue, setValue, ...rest } = props;
     const inputProps = { ...input, ...rest };
 
     return <NavRadio {...inputProps} value={value} checked={value === input.value} id={`id--${value}`} />;

--- a/src/felles-komponenter/skjema/input/Radio.tsx
+++ b/src/felles-komponenter/skjema/input/Radio.tsx
@@ -15,7 +15,7 @@ interface RadioProps {
     touched: boolean;
     error?: string;
     input: FieldStateInput;
-    setValue: (value: string) => void;
+    setValue?: (value: string) => void;
 }
 
 // pristine and initialValue isn't used, but we don't want to pass it to input

--- a/src/felles-komponenter/skjema/input/Select.tsx
+++ b/src/felles-komponenter/skjema/input/Select.tsx
@@ -12,11 +12,12 @@ interface Props {
     touched: boolean;
     error?: string;
     input: FieldStateInput;
+    setValue: (value: string) => void;
 }
 
 // pristine and initialValue isn't used, but we don't want to pass it to input
 const Select = (props: Props & SelectProps) => {
-    const { touched, error, input, pristine, initialValue, noBlankOption, children, ...rest } = props;
+    const { touched, error, input, pristine, initialValue, noBlankOption, children, setValue, ...rest } = props;
     const feil = error && touched ? error : undefined;
     const inputProps = { ...input, ...rest };
 

--- a/src/felles-komponenter/skjema/input/Select.tsx
+++ b/src/felles-komponenter/skjema/input/Select.tsx
@@ -12,7 +12,7 @@ interface Props {
     touched: boolean;
     error?: string;
     input: FieldStateInput;
-    setValue: (value: string) => void;
+    setValue?: (value: string) => void;
 }
 
 // pristine and initialValue isn't used, but we don't want to pass it to input

--- a/src/felles-komponenter/skjema/input/Textarea.tsx
+++ b/src/felles-komponenter/skjema/input/Textarea.tsx
@@ -33,7 +33,7 @@ interface Props {
     textareaClass?: string;
     required?: boolean;
     disabled?: boolean;
-    setValue: (value: string) => void;
+    setValue?: (value: string) => void;
 }
 
 // pristine and initialValue isn't used, but we don't want to pass it to input

--- a/src/felles-komponenter/skjema/input/Textarea.tsx
+++ b/src/felles-komponenter/skjema/input/Textarea.tsx
@@ -33,11 +33,12 @@ interface Props {
     textareaClass?: string;
     required?: boolean;
     disabled?: boolean;
+    setValue: (value: string) => void;
 }
 
 // pristine and initialValue isn't used, but we don't want to pass it to input
 const Textarea = (props: Props) => {
-    const { touched, error, input, pristine, initialValue, visTellerFra, required, ...rest } = props;
+    const { touched, error, input, pristine, initialValue, visTellerFra, required, setValue, ...rest } = props;
     const feil = error && touched ? error : undefined;
     const inputProps = { ...input, ...rest };
 

--- a/src/moduler/aktivitet/aktivitet-forms/behandling-gammel/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/behandling-gammel/validate.js
@@ -2,7 +2,7 @@ import { validerDato } from '../../../../felles-komponenter/skjema/datovelger/ut
 
 export function validateBehandlingType(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (!value || value.trim().length === 0) {
         return 'Du må fylle ut type behandling';
@@ -15,7 +15,7 @@ export function validateBehandlingType(avtalt, value) {
 }
 export function validateBehandlingSted(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (!value || value.trim().length === 0) {
         return 'Du må fylle ut behandlingssted';
@@ -24,22 +24,22 @@ export function validateBehandlingSted(avtalt, value) {
         return `Du må korte ned teksten til 255 tegn`;
     }
 
-    return null;
+    return undefined;
 }
 
 export function validateFeltForLangt(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (value && value.length > 255) {
         return `Du må korte ned teksten til 255 tegn`;
     }
-    return null;
+    return undefined;
 }
 
 export function validateFraDato(avtalt, tilDato, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (!value || value.trim().length === 0) {
         return 'Du må fylle ut fra dato';
@@ -59,10 +59,10 @@ export function validateTilDato(fraDato, value) {
 
 export function validateBeskrivelse(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (value && value.length > 5000) {
         return `Du må korte ned teksten til 5000 tegn`;
     }
-    return null;
+    return undefined;
 }

--- a/src/moduler/aktivitet/aktivitet-forms/behandling-gammel/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/behandling-gammel/validate.js
@@ -2,7 +2,7 @@ import { validerDato } from '../../../../felles-komponenter/skjema/datovelger/ut
 
 export function validateBehandlingType(avtalt, value) {
     if (avtalt) {
-        return undefined;
+        return;
     }
     if (!value || value.trim().length === 0) {
         return 'Du må fylle ut type behandling';
@@ -10,8 +10,6 @@ export function validateBehandlingType(avtalt, value) {
     if (value.length > 100) {
         return `Du må korte ned teksten til 100 tegn`;
     }
-
-    return null;
 }
 export function validateBehandlingSted(avtalt, value) {
     if (avtalt) {
@@ -23,18 +21,15 @@ export function validateBehandlingSted(avtalt, value) {
     if (value.length > 255) {
         return `Du må korte ned teksten til 255 tegn`;
     }
-
-    return undefined;
 }
 
 export function validateFeltForLangt(avtalt, value) {
     if (avtalt) {
-        return undefined;
+        return;
     }
     if (value && value.length > 255) {
         return `Du må korte ned teksten til 255 tegn`;
     }
-    return undefined;
 }
 
 export function validateFraDato(avtalt, tilDato, value) {

--- a/src/moduler/aktivitet/aktivitet-forms/behandling/MedisinskBehandlingForm.tsx
+++ b/src/moduler/aktivitet/aktivitet-forms/behandling/MedisinskBehandlingForm.tsx
@@ -57,7 +57,7 @@ const MedisinskBehandlingForm = (props: Props) => {
     const { onSubmit, aktivitet, isDirtyRef } = props;
 
     const validator = useFormstate<ValideringsProps, Aktivitet>({
-        tittel: () => '',
+        tittel: () => undefined,
         behandlingType: (val, values, aktivitet) => validateBehandlingType(aktivitet.avtalt, val),
         behandlingSted: (val, values, aktivitet) => validateBehandlingSted(aktivitet.avtalt, val),
         fraDato: (val, values, aktivitet: Aktivitet) => validateFraDato(aktivitet.avtalt, aktivitet.tilDato, val),
@@ -83,7 +83,7 @@ const MedisinskBehandlingForm = (props: Props) => {
         periodeValidering: '',
     };
 
-    const state = validator(initalValues, aktivitet);
+    const state = validator(initalValues, aktivitet ? aktivitet : {} as MedisinskBehandlingAktivitet);
 
     if (isDirtyRef) {
         isDirtyRef.current = !state.pristine;

--- a/src/moduler/aktivitet/aktivitet-forms/egen/AktivitetEgenForm.jsx
+++ b/src/moduler/aktivitet/aktivitet-forms/egen/AktivitetEgenForm.jsx
@@ -16,13 +16,15 @@ import Malverk from '../../../malverk/malverk';
 import AktivitetFormHeader from '../aktivitet-form-header';
 import LagreAktivitet from '../LagreAktivitet';
 import {
-    validateBeskrivelse,
-    validateFeltForLangt,
-    validateFraDato,
-    validateLenke,
     validateTilDato,
     validateTittel,
 } from './validate';
+import {
+    validateBeskrivelse,
+    validateFeltForLangt,
+    validateLenke,
+    validateFraDato
+} from '../validate';
 
 function erAvtalt(aktivitet) {
     return aktivitet.avtalt === true;

--- a/src/moduler/aktivitet/aktivitet-forms/egen/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/egen/validate.js
@@ -2,7 +2,7 @@ import { validerDato } from '../../../../felles-komponenter/skjema/datovelger/ut
 
 export function validateTittel(avtalt, value) {
     if (avtalt) {
-        return undefined;
+        return;
     }
     if (!value || value.trim().length <= 0) {
         return 'Du må fylle ut navn på aktiviteten';
@@ -10,48 +10,6 @@ export function validateTittel(avtalt, value) {
     if (value.length > 100) {
         return `Du må korte ned teksten til 100 tegn`;
     }
-
-    return undefined;
-}
-
-export function validateFeltForLangt(avtalt, value) {
-    if (avtalt) {
-        return undefined;
-    }
-    if (value && value.length > 255) {
-        return `Du må korte ned teksten til 255 tegn`;
-    }
-    return undefined;
-}
-
-export function validateBeskrivelse(avtalt, value) {
-    if (avtalt) {
-        return undefined;
-    }
-    if (value && value.length > 5000) {
-        return `Du må korte ned teksten til 5000 tegn`;
-    }
-    return undefined;
-}
-
-export function validateLenke(avtalt, value) {
-    if (avtalt) {
-        return undefined;
-    }
-    if (value && value.length > 2000) {
-        return `Du må korte ned teksten til 2000 tegn`;
-    }
-    return undefined;
-}
-
-export function validateFraDato(avtalt, tilDato, value) {
-    if (avtalt) {
-        return undefined;
-    }
-    if (!value || value.trim().length <= 0) {
-        return 'Du må fylle ut fra dato';
-    }
-    return validerDato(value, tilDato, null);
 }
 
 export function validateTilDato(fraDato, value) {

--- a/src/moduler/aktivitet/aktivitet-forms/egen/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/egen/validate.js
@@ -2,7 +2,7 @@ import { validerDato } from '../../../../felles-komponenter/skjema/datovelger/ut
 
 export function validateTittel(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (!value || value.trim().length <= 0) {
         return 'Du må fylle ut navn på aktiviteten';
@@ -11,42 +11,42 @@ export function validateTittel(avtalt, value) {
         return `Du må korte ned teksten til 100 tegn`;
     }
 
-    return null;
+    return undefined;
 }
 
 export function validateFeltForLangt(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (value && value.length > 255) {
         return `Du må korte ned teksten til 255 tegn`;
     }
-    return null;
+    return undefined;
 }
 
 export function validateBeskrivelse(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (value && value.length > 5000) {
         return `Du må korte ned teksten til 5000 tegn`;
     }
-    return null;
+    return undefined;
 }
 
 export function validateLenke(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (value && value.length > 2000) {
         return `Du må korte ned teksten til 2000 tegn`;
     }
-    return null;
+    return undefined;
 }
 
 export function validateFraDato(avtalt, tilDato, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (!value || value.trim().length <= 0) {
         return 'Du må fylle ut fra dato';

--- a/src/moduler/aktivitet/aktivitet-forms/ijobb/AktivitetIjobbForm.jsx
+++ b/src/moduler/aktivitet/aktivitet-forms/ijobb/AktivitetIjobbForm.jsx
@@ -17,12 +17,10 @@ import * as AppPT from '../../../../proptypes';
 import AktivitetFormHeader from '../aktivitet-form-header';
 import LagreAktivitet from '../LagreAktivitet';
 import {
-    validateBeskrivelse,
-    validateFeltForLangt,
-    validateFraDato,
     validateJobbstatus,
     validateTittel,
 } from './validate';
+import { validateBeskrivelse, validateFeltForLangt, validateFraDato } from '../validate';
 
 function erAvtalt(aktivitet) {
     return aktivitet.avtalt === true;

--- a/src/moduler/aktivitet/aktivitet-forms/ijobb/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/ijobb/validate.js
@@ -1,8 +1,7 @@
-import { validerDato } from '../../../../felles-komponenter/skjema/datovelger/utils';
 
 export function validateTittel(avtalt, value) {
     if (avtalt) {
-        return undefined;
+        return;
     }
     if (!value || value.trim().length <= 0) {
         return 'Du må fylle ut stillingstittel';
@@ -10,46 +9,13 @@ export function validateTittel(avtalt, value) {
     if (value.length > 100) {
         return `Du må korte ned teksten til 100 tegn`;
     }
-
-    return undefined;
-}
-
-export function validateFeltForLangt(avtalt, value) {
-    if (avtalt) {
-        return undefined;
-    }
-    if (value && value.length > 255) {
-        return `Du må korte ned teksten til 255 tegn`;
-    }
-    return undefined;
-}
-
-export function validateBeskrivelse(avtalt, value) {
-    if (avtalt) {
-        return undefined;
-    }
-    if (value && value.length > 5000) {
-        return `Du må korte ned teksten til 5000 tegn`;
-    }
-    return undefined;
 }
 
 export function validateJobbstatus(avtalt, value) {
     if (avtalt) {
-        return undefined;
+        return;
     }
     if (!value || value.length <= 0) {
         return 'Du må velge heltid eller deltid';
     }
-    return undefined;
-}
-
-export function validateFraDato(avtalt, tilDato, value) {
-    if (avtalt) {
-        return undefined;
-    }
-    if (!value || value.trim().length <= 0) {
-        return 'Du må fylle ut fra dato';
-    }
-    return validerDato(value, tilDato, null);
 }

--- a/src/moduler/aktivitet/aktivitet-forms/ijobb/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/ijobb/validate.js
@@ -2,7 +2,7 @@ import { validerDato } from '../../../../felles-komponenter/skjema/datovelger/ut
 
 export function validateTittel(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (!value || value.trim().length <= 0) {
         return 'Du må fylle ut stillingstittel';
@@ -11,42 +11,42 @@ export function validateTittel(avtalt, value) {
         return `Du må korte ned teksten til 100 tegn`;
     }
 
-    return null;
+    return undefined;
 }
 
 export function validateFeltForLangt(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (value && value.length > 255) {
         return `Du må korte ned teksten til 255 tegn`;
     }
-    return null;
+    return undefined;
 }
 
 export function validateBeskrivelse(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (value && value.length > 5000) {
         return `Du må korte ned teksten til 5000 tegn`;
     }
-    return null;
+    return undefined;
 }
 
 export function validateJobbstatus(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (!value || value.length <= 0) {
         return 'Du må velge heltid eller deltid';
     }
-    return null;
+    return undefined;
 }
 
 export function validateFraDato(avtalt, tilDato, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (!value || value.trim().length <= 0) {
         return 'Du må fylle ut fra dato';

--- a/src/moduler/aktivitet/aktivitet-forms/mote/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/mote/validate.js
@@ -19,7 +19,7 @@ function erVerdiSatt(value) {
 
 export function validateTittel(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
 
     if (!erVerdiSatt(value)) {
@@ -30,7 +30,7 @@ export function validateTittel(avtalt, value) {
         return TITTEL_MAKS_LENGDE_TEKST;
     }
 
-    return null;
+    return undefined;
 }
 
 export function validateAdresse(avtalt, value) {
@@ -42,7 +42,7 @@ export function validateAdresse(avtalt, value) {
         return ADRESSE_MAKS_LENGDE_TEKST;
     }
 
-    return null;
+    return undefined;
 }
 
 export function validateFraDato(avtalt, tilDato, value) {
@@ -55,7 +55,7 @@ export function validateFraDato(avtalt, tilDato, value) {
 
 export function validateHensikt(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
 
     if (!erVerdiSatt(value)) {
@@ -66,19 +66,19 @@ export function validateHensikt(avtalt, value) {
         return HENSIKT_MAKS_LENGDE_TEKST;
     }
 
-    return null;
+    return undefined;
 }
 
 export function validateForberedelser(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
 
     if (tekstForLang(FORBEREDELSER_MAKS_LENGDE, value)) {
         return FORBEREDELSER_MAKS_LENGDE_TEKST;
     }
 
-    return null;
+    return undefined;
 }
 
 export function validateKlokkeslett(avtalt, value) {
@@ -86,7 +86,7 @@ export function validateKlokkeslett(avtalt, value) {
         return 'Du må fylle ut klokkeslett';
     }
 
-    return null;
+    return undefined;
 }
 
 export function validateVarighet(avtalt, value) {
@@ -94,12 +94,12 @@ export function validateVarighet(avtalt, value) {
         return 'Du må fylle ut varighet';
     }
 
-    return null;
+    return undefined;
 }
 export function validateKanal(avtalt, value) {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut møteform';
     }
 
-    return null;
+    return undefined;
 }

--- a/src/moduler/aktivitet/aktivitet-forms/mote/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/mote/validate.js
@@ -19,7 +19,7 @@ function erVerdiSatt(value) {
 
 export function validateTittel(avtalt, value) {
     if (avtalt) {
-        return undefined;
+        return;
     }
 
     if (!erVerdiSatt(value)) {
@@ -29,8 +29,6 @@ export function validateTittel(avtalt, value) {
     if (tekstForLang(TITTEL_MAKS_LENGDE, value)) {
         return TITTEL_MAKS_LENGDE_TEKST;
     }
-
-    return undefined;
 }
 
 export function validateAdresse(avtalt, value) {
@@ -41,8 +39,6 @@ export function validateAdresse(avtalt, value) {
     if (tekstForLang(ADRESSE_MAKS_LENGDE, value)) {
         return ADRESSE_MAKS_LENGDE_TEKST;
     }
-
-    return undefined;
 }
 
 export function validateFraDato(avtalt, tilDato, value) {
@@ -55,7 +51,7 @@ export function validateFraDato(avtalt, tilDato, value) {
 
 export function validateHensikt(avtalt, value) {
     if (avtalt) {
-        return undefined;
+        return;
     }
 
     if (!erVerdiSatt(value)) {
@@ -65,41 +61,31 @@ export function validateHensikt(avtalt, value) {
     if (tekstForLang(HENSIKT_MAKS_LENGDE, value)) {
         return HENSIKT_MAKS_LENGDE_TEKST;
     }
-
-    return undefined;
 }
 
 export function validateForberedelser(avtalt, value) {
     if (avtalt) {
-        return undefined;
+        return;
     }
 
     if (tekstForLang(FORBEREDELSER_MAKS_LENGDE, value)) {
         return FORBEREDELSER_MAKS_LENGDE_TEKST;
     }
-
-    return undefined;
 }
 
 export function validateKlokkeslett(avtalt, value) {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut klokkeslett';
     }
-
-    return undefined;
 }
 
 export function validateVarighet(avtalt, value) {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut varighet';
     }
-
-    return undefined;
 }
 export function validateKanal(avtalt, value) {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut møteform';
     }
-
-    return undefined;
 }

--- a/src/moduler/aktivitet/aktivitet-forms/samtalereferat/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/samtalereferat/validate.js
@@ -7,8 +7,6 @@ export function validateTittel(value) {
     if (value.length > 100) {
         return `Du må korte ned teksten til 100 tegn`;
     }
-
-    return undefined;
 }
 
 export function validateReferat(value) {
@@ -18,14 +16,12 @@ export function validateReferat(value) {
     if (value && value.length > 5000) {
         return `Du må korte ned teksten til 5000 tegn`;
     }
-    return undefined;
 }
 
 export function validateKanal(value) {
     if (value.length === 0) {
         return 'Du må fylle ut samtaleform';
     }
-    return undefined;
 }
 
 export function validateFraDato(value) {

--- a/src/moduler/aktivitet/aktivitet-forms/samtalereferat/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/samtalereferat/validate.js
@@ -8,7 +8,7 @@ export function validateTittel(value) {
         return `Du må korte ned teksten til 100 tegn`;
     }
 
-    return null;
+    return undefined;
 }
 
 export function validateReferat(value) {
@@ -18,14 +18,14 @@ export function validateReferat(value) {
     if (value && value.length > 5000) {
         return `Du må korte ned teksten til 5000 tegn`;
     }
-    return null;
+    return undefined;
 }
 
 export function validateKanal(value) {
     if (value.length === 0) {
         return 'Du må fylle ut samtaleform';
     }
-    return null;
+    return undefined;
 }
 
 export function validateFraDato(value) {

--- a/src/moduler/aktivitet/aktivitet-forms/sokeavtale/AktivitetSokeavtaleForm.jsx
+++ b/src/moduler/aktivitet/aktivitet-forms/sokeavtale/AktivitetSokeavtaleForm.jsx
@@ -32,7 +32,7 @@ export default function SokeAvtaleAktivitetForm(props) {
     const { onSubmit, aktivitet, isDirtyRef, endre } = props;
 
     const validator = useFormstate({
-        tittel: () => null,
+        tittel: () => undefined,
         fraDato: (val, values, aktivitet) => validateFraDato(erAvtalt(aktivitet), aktivitet.tilDato, val),
         tilDato: (val, values, aktivitet) => validateTilDato(erAvtalt(aktivitet), aktivitet.fraDato, val),
         periodeValidering: (val, values) => validerPeriodeFelt(values.fraDato, values.tilDato),

--- a/src/moduler/aktivitet/aktivitet-forms/sokeavtale/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/sokeavtale/validate.js
@@ -2,38 +2,35 @@ import { validerDato } from '../../../../felles-komponenter/skjema/datovelger/ut
 
 export function validateBeskrivelse(avtalt, value) {
     if (avtalt) {
-        return undefined;
+        return;
     }
     if (value && value.length > 5000) {
         return `Du må korte ned teksten til 5000 tegn`;
     }
-    return undefined;
 }
 
 export function validateOppfolging(avtalt, value) {
     if (avtalt) {
-        return undefined;
+        return;
     }
     if (value && value.length > 255) {
         return `Du må korte ned teksten til 255 tegn`;
     }
-    return undefined;
 }
 
 export function validateAntallStillinger(avtalt, value) {
     if (avtalt || !value) {
-        return undefined;
+        return;
     }
 
     if (!Number.isInteger(Number(value))) {
         return 'Antall må være et heltall';
     }
-    return undefined;
 }
 
 export function validateAntallStillingerIUken(avtalt, value, antallStillingerSokes) {
     if (avtalt || !!antallStillingerSokes) {
-        return undefined;
+        return;
     }
 
     if (value.length === 0) {
@@ -43,7 +40,6 @@ export function validateAntallStillingerIUken(avtalt, value, antallStillingerSok
     if (!Number.isInteger(Number(value))) {
         return 'Antall må være et heltall';
     }
-    return undefined;
 }
 
 export function validateFraDato(avtalt, tilDato, value) {

--- a/src/moduler/aktivitet/aktivitet-forms/sokeavtale/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/sokeavtale/validate.js
@@ -2,38 +2,38 @@ import { validerDato } from '../../../../felles-komponenter/skjema/datovelger/ut
 
 export function validateBeskrivelse(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (value && value.length > 5000) {
         return `Du må korte ned teksten til 5000 tegn`;
     }
-    return null;
+    return undefined;
 }
 
 export function validateOppfolging(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (value && value.length > 255) {
         return `Du må korte ned teksten til 255 tegn`;
     }
-    return null;
+    return undefined;
 }
 
 export function validateAntallStillinger(avtalt, value) {
     if (avtalt || !value) {
-        return null;
+        return undefined;
     }
 
     if (!Number.isInteger(Number(value))) {
         return 'Antall må være et heltall';
     }
-    return null;
+    return undefined;
 }
 
 export function validateAntallStillingerIUken(avtalt, value, antallStillingerSokes) {
     if (avtalt || !!antallStillingerSokes) {
-        return null;
+        return undefined;
     }
 
     if (value.length === 0) {
@@ -43,7 +43,7 @@ export function validateAntallStillingerIUken(avtalt, value, antallStillingerSok
     if (!Number.isInteger(Number(value))) {
         return 'Antall må være et heltall';
     }
-    return null;
+    return undefined;
 }
 
 export function validateFraDato(avtalt, tilDato, value) {

--- a/src/moduler/aktivitet/aktivitet-forms/stilling/AktivitetStillingForm.jsx
+++ b/src/moduler/aktivitet/aktivitet-forms/stilling/AktivitetStillingForm.jsx
@@ -15,7 +15,13 @@ import Textarea from '../../../../felles-komponenter/skjema/input/Textarea';
 import * as AppPT from '../../../../proptypes';
 import AktivitetFormHeader from '../aktivitet-form-header';
 import LagreAktivitet from '../LagreAktivitet';
-import { validateBeskrivelse, validateFeltForLangt, validateFraDato, validateLenke, validateTittel } from './validate';
+import { validateTittel } from './validate';
+import {
+    validateBeskrivelse,
+    validateFeltForLangt,
+    validateLenke,
+    validateFraDato
+} from '../validate';
 import { todayIsoString } from '../../../../utils/dateUtils';
 
 function erAvtalt(aktivitet) {

--- a/src/moduler/aktivitet/aktivitet-forms/stilling/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/stilling/validate.js
@@ -1,8 +1,7 @@
-import { validerDato } from '../../../../felles-komponenter/skjema/datovelger/utils';
 
 export function validateTittel(avtalt, value) {
     if (avtalt) {
-        return undefined;
+        return;
     }
     if (!value || value.trim().length <= 0) {
         return 'Du må fylle ut stillingstittel';
@@ -10,43 +9,4 @@ export function validateTittel(avtalt, value) {
     if (value.length > 100) {
         return `Du må korte ned teksten til 100 tegn`;
     }
-
-    return undefined;
-}
-
-export function validateFeltForLangt(avtalt, value) {
-    if (avtalt) {
-        return undefined;
-    }
-    if (value && value.length > 255) {
-        return `Du må korte ned teksten til 255 tegn`;
-    }
-    return undefined;
-}
-
-export function validateBeskrivelse(avtalt, value) {
-    if (avtalt) {
-        return undefined;
-    }
-    if (value && value.length > 5000) {
-        return `Du må korte ned teksten til 5000 tegn`;
-    }
-    return undefined;
-}
-
-export function validateLenke(value) {
-    if (value && value.length > 2000) {
-        return `Lenken kan ikke være lenger enn 2000 tegn`;
-    }
-    return undefined;
-}
-
-export function validateFraDato(avtalt, tilDato, value) {
-    if (avtalt) {
-        return undefined;
-    }
-    if (!value || value.trim().length <= 0) {
-        return 'Du må fylle ut fra dato';
-    }
-    return validerDato(value, tilDato, null);
 }

--- a/src/moduler/aktivitet/aktivitet-forms/stilling/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/stilling/validate.js
@@ -2,7 +2,7 @@ import { validerDato } from '../../../../felles-komponenter/skjema/datovelger/ut
 
 export function validateTittel(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (!value || value.trim().length <= 0) {
         return 'Du må fylle ut stillingstittel';
@@ -11,39 +11,39 @@ export function validateTittel(avtalt, value) {
         return `Du må korte ned teksten til 100 tegn`;
     }
 
-    return null;
+    return undefined;
 }
 
 export function validateFeltForLangt(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (value && value.length > 255) {
         return `Du må korte ned teksten til 255 tegn`;
     }
-    return null;
+    return undefined;
 }
 
 export function validateBeskrivelse(avtalt, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (value && value.length > 5000) {
         return `Du må korte ned teksten til 5000 tegn`;
     }
-    return null;
+    return undefined;
 }
 
 export function validateLenke(value) {
     if (value && value.length > 2000) {
         return `Lenken kan ikke være lenger enn 2000 tegn`;
     }
-    return null;
+    return undefined;
 }
 
 export function validateFraDato(avtalt, tilDato, value) {
     if (avtalt) {
-        return null;
+        return undefined;
     }
     if (!value || value.trim().length <= 0) {
         return 'Du må fylle ut fra dato';

--- a/src/moduler/aktivitet/aktivitet-forms/validate.js
+++ b/src/moduler/aktivitet/aktivitet-forms/validate.js
@@ -1,0 +1,38 @@
+import { validerDato } from '../../../felles-komponenter/skjema/datovelger/utils';
+
+export function validateFeltForLangt(avtalt, value) {
+    if (avtalt) {
+        return undefined;
+    }
+    if (value && value.length > 255) {
+        return `Du må korte ned teksten til 255 tegn`;
+    }
+}
+
+export function validateBeskrivelse(avtalt, value) {
+    if (avtalt) {
+        return;
+    }
+    if (value && value.length > 5000) {
+        return `Du må korte ned teksten til 5000 tegn`;
+    }
+}
+
+export function validateLenke(avtalt, value) {
+    if (avtalt) {
+        return;
+    }
+    if (value && value.length > 2000) {
+        return `Du må korte ned teksten til 2000 tegn`;
+    }
+}
+
+export function validateFraDato(avtalt, tilDato, value) {
+    if (avtalt) {
+        return;
+    }
+    if (!value || value.trim().length <= 0) {
+        return 'Du må fylle ut fra dato';
+    }
+    return validerDato(value, tilDato, null);
+}

--- a/src/moduler/aktivitet/visning/avtalt-container-gammel/AvtaltForm.tsx
+++ b/src/moduler/aktivitet/visning/avtalt-container-gammel/AvtaltForm.tsx
@@ -86,7 +86,14 @@ const AvtaltForm = (props: Props) => {
         visAvtaltMedNavMindreEnnSyvDager,
     } = props;
 
-    const validator = useFormstate({
+    type FormType = {
+        avtaltCheckbox: string,
+        avtaltSelect: string,
+        avtaltText119: string,
+        avtaltText: string
+    }
+
+    const validator = useFormstate<FormType>({
         avtaltCheckbox: noValidate,
         avtaltSelect: noValidate,
         avtaltText119: validateForhandsorienter,

--- a/src/moduler/aktivitet/visning/avtalt-container/aktivitet/AvtaltForm.tsx
+++ b/src/moduler/aktivitet/visning/avtalt-container/aktivitet/AvtaltForm.tsx
@@ -47,7 +47,7 @@ const avtaltTekst119 =
     '[komme på møtet vi har innkalt deg til [dato]/ møte på … /levere ... innen [dato]] uten rimelig grunn. Dette går ' +
     'fram av folketrygdloven § 11-9.';
 
-interface SubmitProps {
+type SubmitProps = {
     avtaltCheckbox: string;
     forhaandsorienteringType: ForhaandsorienteringType;
     avtaltText119: string;

--- a/src/moduler/aktivitet/visning/avtalt-container/arena-aktivitet/ForhaandsorienteringForm.tsx
+++ b/src/moduler/aktivitet/visning/avtalt-container/arena-aktivitet/ForhaandsorienteringForm.tsx
@@ -42,13 +42,19 @@ interface Props {
     setForhandsorienteringType(type: ForhaandsorienteringType): void;
 }
 
+type FormType = {
+    tekst: string,
+    checked: string,
+    forhaandsorienteringType: string
+}
+
 const ForhaandsorienteringForm = (props: Props) => {
     const { setSendtAtErAvtaltMedNav, setForhandsorienteringType, aktivitet, hidden } = props;
 
     const dialogStatus = useSelector(selectDialogStatus);
     const dispatch = useDispatch();
 
-    const validator = useFormstate({
+    const validator = useFormstate<FormType>({
         tekst: validate,
         checked: () => undefined,
         forhaandsorienteringType: () => undefined,

--- a/src/moduler/aktivitet/visning/etikett-oppdatering/StillingEtikettForm.tsx
+++ b/src/moduler/aktivitet/visning/etikett-oppdatering/StillingEtikettForm.tsx
@@ -16,10 +16,14 @@ interface Props {
     onSubmit(val: { etikettstatus: string }): Promise<any>;
 }
 
+type FormType = {
+    etikettstatus: string
+}
+
 const StillingEtikettForm = (props: Props) => {
     const { aktivitet, disabled = true, onSubmit } = props;
 
-    const validator = useFormstate({
+    const validator = useFormstate<FormType>({
         etikettstatus: validateEtikettStatus,
     });
 

--- a/src/moduler/mal/MalForm.tsx
+++ b/src/moduler/mal/MalForm.tsx
@@ -28,11 +28,15 @@ interface Props {
     handleComplete: () => void;
 }
 
+type FormType = {
+    mal: string
+};
+
 function MalForm(props: Props) {
     const dispatch = useReduxDispatch();
     const { mal, isDirty, handleComplete } = props;
 
-    const validator = useFormstate({
+    const validator = useFormstate<FormType>({
         mal: validateMal,
     });
 

--- a/src/moduler/utskrift/printMelding.tsx
+++ b/src/moduler/utskrift/printMelding.tsx
@@ -17,10 +17,14 @@ interface Props {
     hidden?: boolean;
 }
 
+type FormType = {
+    beskrivelse: string
+}
+
 function PrintMeldingForm(props: Props) {
     const { bruker, onSubmit, hidden } = props;
 
-    const validator = useFormstate({
+    const validator = useFormstate<FormType>({
         beskrivelse: (val) => (val.length > 2000 ? 'Du må korte ned teksten til 2000 tegn' : undefined),
     });
 
@@ -28,7 +32,7 @@ function PrintMeldingForm(props: Props) {
         beskrivelse: defaultBeskrivelse,
     });
 
-    const submit = (form: { beskrivelse: string }) => {
+    const submit = (form: FormType) => {
         return onSubmit(form.beskrivelse);
     };
 

--- a/src/moduler/utskrift/velgPlan/velgPlanUtskriftForm.tsx
+++ b/src/moduler/utskrift/velgPlan/velgPlanUtskriftForm.tsx
@@ -13,11 +13,14 @@ interface VelgPlanUtskriftFormProps {
     hidden?: boolean;
     kvpPerioder?: KvpPeriode[];
 }
+type FormType = {
+    utskriftPlanType: string
+}
 
 function VelgPlanUtskriftForm(props: VelgPlanUtskriftFormProps) {
     const { onSubmit, kvpPerioder, hidden } = props;
 
-    const validator = useFormstate({
+    const validator = useFormstate<FormType>({
         utskriftPlanType: () => undefined,
     });
 


### PR DESCRIPTION
På grunn av oppgradering av react, trenger vi å løfte versjonen på dette biblioteket. Det har vært en del breaking changes som fører til endringer i vår kode:
* strengere typing for useFormState()
* valideringsfunksjoner må returnere undefined, og ikke null ved validering ok
* ny funksjon setValue på FieldState og FormState må innkorporeres i våre custom inputkomponenter

Fikk veldig god hjelp av Nicklas Utgaard for å finne ut hva som måtte gjøres. 