### PR TITLE
Dropper sjekk av om arenadata er lastet ved fullfør, avbryt, filter og print

### DIFF
--- a/src/moduler/aktivitet/aktivitetlisteSelector.ts
+++ b/src/moduler/aktivitet/aktivitetlisteSelector.ts
@@ -7,11 +7,7 @@ import { aktivitetFilter, selectDatoErIPeriode } from '../filtrering/filter/filt
 import { selectErVeileder, selectIdentitetStatus } from '../identitet/identitet-selector';
 import { selectOppfolgingStatus } from '../oppfolging-status/oppfolging-selector';
 import { selectAktivitetStatus, selectAktiviteterData, selectAktiviteterSlice } from './aktivitet-selector';
-import {
-    selectArenaAktivitetStatus,
-    selectArenaAktiviteterData,
-    selectArenaAktiviteterSlice,
-} from './arena-aktivitet-selector';
+import { selectArenaAktiviteterData, selectArenaAktiviteterSlice } from './arena-aktivitet-selector';
 
 export const selectAlleAktiviter = createSelector(
     selectAktiviteterData,
@@ -32,8 +28,7 @@ export const selectAktivitetListeSlice = (state: any) => {
     const status = aggregerStatus(
         selectOppfolgingStatus(state),
         selectIdentitetStatus(state),
-        selectAktivitetStatus(state),
-        selectArenaAktivitetStatus(state)
+        selectAktivitetStatus(state)
     );
     return {
         status,


### PR DESCRIPTION
Slik det var vil fullfør/avbryt med drag and drop ikke virke når arena er nede.
Filter vil heller ikke virke, og ikke utskriftsdialogen.
Sjekken av arenadata er tatt bort fra disse funksjonene.
https://trello.com/c/cGiTNo9d