### PR TITLE
Flytte aktivitet utifra svar på dele cv spm

### DIFF
--- a/src/datatypes/aktivitetTypes.ts
+++ b/src/datatypes/aktivitetTypes.ts
@@ -6,6 +6,11 @@ import {
     MOTE_TYPE,
     SAMTALEREFERAT_TYPE,
     SOKEAVTALE_AKTIVITET_TYPE,
+    STATUS_AVBRUTT,
+    STATUS_BRUKER_ER_INTRESSERT,
+    STATUS_FULLFOERT,
+    STATUS_GJENNOMFOERT,
+    STATUS_PLANLAGT,
     STILLING_AKTIVITET_TYPE,
     STILLING_FRA_NAV_TYPE,
     TILTAK_AKTIVITET_TYPE,
@@ -13,7 +18,7 @@ import {
 } from '../constant';
 
 type StringOrNull = string | null;
-//aktivitetType definisjonen bor også i .\const som *_AKTIVITET_TYPE finens det noen smartere måte å gjøre dette på?
+
 export type AktivitetType =
     | typeof EGEN_AKTIVITET_TYPE
     | typeof STILLING_AKTIVITET_TYPE
@@ -27,8 +32,13 @@ export type AktivitetType =
     | typeof SAMTALEREFERAT_TYPE
     | typeof STILLING_FRA_NAV_TYPE;
 
-//aktivitetStatusd efinisjonen bor også i .\const som STATUS_*
-export type AktivitetStatus = 'AVBRUTT' | 'FULLFORT' | 'GJENNOMFORES' | 'PLANLAGT' | 'BRUKER_ER_INTERESSERT';
+export type AktivitetStatus =
+    | typeof STATUS_AVBRUTT
+    | typeof STATUS_FULLFOERT
+    | typeof STATUS_GJENNOMFOERT
+    | typeof STATUS_PLANLAGT
+    | typeof STATUS_BRUKER_ER_INTRESSERT;
+
 export type StillingsStatus = 'INGEN_VALGT' | 'SOKNAD_SENDT' | 'INNKALT_TIL_INTERVJU' | 'AVSLAG' | 'JOBBTILBUD';
 export enum TransaksjonsType {
     OPPRETTET = 'OPPRETTET',

--- a/src/index.less
+++ b/src/index.less
@@ -48,10 +48,6 @@
         }
     }
 
-    .alertstripe__ikon {
-        margin-right: 1rem;
-    }
-
     .alertstripe:not(.alertstripe--solid) .alertstripe__ikon:after {
         background-color: @white;
     }

--- a/src/moduler/aktivitet/ulest-markering/UlestMarkering.tsx
+++ b/src/moduler/aktivitet/ulest-markering/UlestMarkering.tsx
@@ -1,7 +1,6 @@
-import { Element } from 'nav-frontend-typografi';
 import React from 'react';
 
-import { ReactComponent as UlestViktigIkon } from '../../../Ikoner/advarsel-ikon.svg';
+import { CustomAlertstripe } from '../visning/hjelpekomponenter/CustomAlertstripe';
 import styles from './UlestMarkering.module.less';
 
 interface Props {
@@ -15,10 +14,7 @@ const UlestMarkering = (props: Props) => {
     }
 
     return (
-        <div className={styles.ulestMarkering}>
-            <UlestViktigIkon />
-            <Element className={styles.ulestTekst}>Ulest</Element>
-        </div>
+        <CustomAlertstripe tekst="Ulest" sectionClassName={styles.ulestMarkering} textClassName={styles.ulestTekst} />
     );
 };
 

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/AktivitetinformasjonVisning.tsx
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/AktivitetinformasjonVisning.tsx
@@ -77,7 +77,7 @@ const AktivitetinformasjonVisning = (props: Props) => {
             <div className={styles.underseksjon}>
                 <Aktivitetsdetaljer valgtAktivitet={valgtAktivitet} />
             </div>
-            {valgtAktivitet.type === STILLING_FRA_NAV_TYPE && <MeldInteresseForStillingen />}
+            {valgtAktivitet.type === STILLING_FRA_NAV_TYPE && <MeldInteresseForStillingen aktivitet={valgtAktivitet} />}
             <DeleLinje />
         </div>
     );

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/CustomAlertstripe.module.less
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/CustomAlertstripe.module.less
@@ -1,0 +1,8 @@
+.overskrift {
+    display: flex;
+    align-items: flex-end;
+}
+
+.tekst {
+    margin-left: 0.75rem;
+}

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/CustomAlertstripe.tsx
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/CustomAlertstripe.tsx
@@ -10,11 +10,9 @@ interface Props {
     textClassName?: string;
 }
 
-export const CustomAlertstripe = (props: Props) => {
-    return (
-        <div className={props.sectionClassName ? props.sectionClassName : styles.overskrift}>
-            <VarselIkon />
-            <Element className={props.textClassName ? props.textClassName : styles.tekst}>{props.tekst}</Element>
-        </div>
-    );
-};
+export const CustomAlertstripe = (props: Props) => (
+    <div className={props.sectionClassName ? props.sectionClassName : styles.overskrift}>
+        <VarselIkon />
+        <Element className={props.textClassName ? props.textClassName : styles.tekst}>{props.tekst}</Element>
+    </div>
+);

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/CustomAlertstripe.tsx
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/CustomAlertstripe.tsx
@@ -1,0 +1,20 @@
+import { Element } from 'nav-frontend-typografi';
+import React from 'react';
+
+import { ReactComponent as VarselIkon } from '../../../../Ikoner/advarsel-ikon.svg';
+import styles from './CustomAlertstripe.module.less';
+
+interface Props {
+    tekst: string;
+    sectionClassName?: string;
+    textClassName?: string;
+}
+
+export const CustomAlertstripe = (props: Props) => {
+    return (
+        <div className={props.sectionClassName ? props.sectionClassName : styles.overskrift}>
+            <VarselIkon />
+            <Element className={props.textClassName ? props.textClassName : styles.tekst}>{props.tekst}</Element>
+        </div>
+    );
+};

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/MeldInteresseForStilling.tsx
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/MeldInteresseForStilling.tsx
@@ -29,15 +29,16 @@ export const MeldInteresseForStillingen = ({ aktivitet }: PropTypes) => {
     const onChange = (event: any, value: string) => {
         setValgtAlternativ(value as SvarType);
 
-        if (value == SvarType.JA) {
+        if (value === SvarType.JA) {
             setInfoTekst('Stillingen flyttes til "Gjennomfører"');
         }
-        if (value == SvarType.NEI) {
+        if (value === SvarType.NEI) {
             setInfoTekst('Stillingen flyttes til "Avbrutt"');
         }
     };
 
     const onClick = () => {
+        //Her skal vi lage et eget endepunkt som ikke finnes enda
         if (valgtAlternativ === SvarType.JA) {
             lagreStatusEndringer(dispatch, { aktivitetstatus: STATUS_GJENNOMFOERT }, aktivitet);
         } else if (valgtAlternativ === SvarType.NEI) {

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/MeldInteresseForStilling.tsx
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/MeldInteresseForStilling.tsx
@@ -1,16 +1,15 @@
 import AlertStripe from 'nav-frontend-alertstriper';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { RadioPanelGruppe } from 'nav-frontend-skjema';
-import { Element } from 'nav-frontend-typografi';
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { STATUS_AVBRUTT, STATUS_GJENNOMFOERT } from '../../../../constant';
 import { Aktivitet } from '../../../../datatypes/aktivitetTypes';
-import { ReactComponent as VarselIkon } from '../../../../Ikoner/advarsel-ikon.svg';
 import DeleLinje from '../delelinje/delelinje';
 import { lagreStatusEndringer } from '../status-oppdatering/oppdater-aktivitet-status';
 import detaljVisningStyles from './AktivitetinformasjonVisning.module.less';
+import { CustomAlertstripe } from './CustomAlertstripe';
 import styles from './MeldInteresseForStillingen.module.less';
 
 enum SvarType {
@@ -23,12 +22,12 @@ interface PropTypes {
 }
 
 export const MeldInteresseForStillingen = ({ aktivitet }: PropTypes) => {
-    const [svar, setSvar] = useState<SvarType | undefined>(undefined);
+    const [valgtAlternativ, setValgtAlternativ] = useState<SvarType | undefined>(undefined);
     const [infoTekst, setInfoTekst] = useState<string | undefined>(undefined);
     const dispatch = useDispatch();
 
     const onChange = (event: any, value: string) => {
-        setSvar(value as SvarType);
+        setValgtAlternativ(value as SvarType);
 
         if (value == SvarType.JA) {
             setInfoTekst('Stillingen flyttes til "Gjennomfører"');
@@ -38,17 +37,20 @@ export const MeldInteresseForStillingen = ({ aktivitet }: PropTypes) => {
         }
     };
 
-    const endreAktivitetstatus = () => {
-        if (svar === SvarType.JA) {
+    const onClick = () => {
+        if (valgtAlternativ === SvarType.JA) {
             lagreStatusEndringer(dispatch, { aktivitetstatus: STATUS_GJENNOMFOERT }, aktivitet);
-        } else if (svar === SvarType.NEI) {
+        } else if (valgtAlternativ === SvarType.NEI) {
             lagreStatusEndringer(dispatch, { aktivitetstatus: STATUS_AVBRUTT }, aktivitet);
         }
     };
 
-    const onClick = () => {
-        endreAktivitetstatus();
-    };
+    const HeaderMedIngress = () => (
+        <>
+            <CustomAlertstripe tekst="Er du interessert i denne stillingen?" />
+            <p className={styles.ingress}>Du bestemmer selv om nav skal dele CV-en din på denne stillingen</p>
+        </>
+    );
 
     return (
         <>
@@ -56,17 +58,7 @@ export const MeldInteresseForStillingen = ({ aktivitet }: PropTypes) => {
             <div className={detaljVisningStyles.underseksjon}>
                 <RadioPanelGruppe
                     name="MeldInteresseForStillingen"
-                    legend={
-                        <>
-                            <div className={styles.overskrift}>
-                                <VarselIkon className={styles.varselIkon} />
-                                <Element className={styles.tekst}>Er du interessert i denne stillingen?</Element>
-                            </div>
-                            <p className={styles.ingress}>
-                                Du bestemmer selv om nav skal dele CV-en din på denne stillingen
-                            </p>
-                        </>
-                    }
+                    legend={<HeaderMedIngress />}
                     radios={[
                         {
                             label: 'Ja, og NAV kan dele CV-en min med arbeidsgiver',
@@ -79,17 +71,19 @@ export const MeldInteresseForStillingen = ({ aktivitet }: PropTypes) => {
                             id: SvarType.NEI.toString(),
                         },
                     ]}
-                    checked={svar?.toString()}
+                    checked={valgtAlternativ?.toString()}
                     onChange={onChange}
                 />
                 {infoTekst && (
-                    <AlertStripe type="info" form="inline" className={styles.infoboks}>
-                        {infoTekst}
-                    </AlertStripe>
+                    <AlertStripe children={infoTekst} type="info" form="inline" className={styles.infoboks} />
                 )}
-                <Hovedknapp mini className={styles.knapp} onClick={onClick} disabled={!svar}>
-                    Lagre
-                </Hovedknapp>
+                <Hovedknapp
+                    children="Lagre"
+                    mini
+                    className={styles.knapp}
+                    onClick={onClick}
+                    disabled={!valgtAlternativ}
+                />
             </div>
         </>
     );

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/MeldInteresseForStilling.tsx
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/MeldInteresseForStilling.tsx
@@ -1,23 +1,53 @@
+import AlertStripe from 'nav-frontend-alertstriper';
 import { Hovedknapp } from 'nav-frontend-knapper';
 import { RadioPanelGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
 import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
 
+import { STATUS_AVBRUTT, STATUS_GJENNOMFOERT } from '../../../../constant';
+import { Aktivitet } from '../../../../datatypes/aktivitetTypes';
 import { ReactComponent as VarselIkon } from '../../../../Ikoner/advarsel-ikon.svg';
 import DeleLinje from '../delelinje/delelinje';
+import { lagreStatusEndringer } from '../status-oppdatering/oppdater-aktivitet-status';
 import detaljVisningStyles from './AktivitetinformasjonVisning.module.less';
 import styles from './MeldInteresseForStillingen.module.less';
 
 enum SvarType {
-    JA,
-    NEI,
+    JA = 'ja',
+    NEI = 'nei',
 }
 
-export const MeldInteresseForStillingen = () => {
-    const [svar, setSvar] = useState<string>('');
+interface PropTypes {
+    aktivitet: Aktivitet;
+}
+
+export const MeldInteresseForStillingen = ({ aktivitet }: PropTypes) => {
+    const [svar, setSvar] = useState<SvarType | undefined>(undefined);
+    const [infoTekst, setInfoTekst] = useState<string | undefined>(undefined);
+    const dispatch = useDispatch();
 
     const onChange = (event: any, value: string) => {
-        setSvar(value);
+        setSvar(value as SvarType);
+
+        if (value == SvarType.JA) {
+            setInfoTekst('Stillingen flyttes til "Gjennomfører"');
+        }
+        if (value == SvarType.NEI) {
+            setInfoTekst('Stillingen flyttes til "Avbrutt"');
+        }
+    };
+
+    const endreAktivitetstatus = () => {
+        if (svar === SvarType.JA) {
+            lagreStatusEndringer(dispatch, { aktivitetstatus: STATUS_GJENNOMFOERT }, aktivitet);
+        } else if (svar === SvarType.NEI) {
+            lagreStatusEndringer(dispatch, { aktivitetstatus: STATUS_AVBRUTT }, aktivitet);
+        }
+    };
+
+    const onClick = () => {
+        endreAktivitetstatus();
     };
 
     return (
@@ -27,27 +57,37 @@ export const MeldInteresseForStillingen = () => {
                 <RadioPanelGruppe
                     name="MeldInteresseForStillingen"
                     legend={
-                        <div className={styles.overskrift}>
-                            <VarselIkon className={styles.varselIkon} />
-                            <Element className={styles.tekst}>Er du interessert i denne stillingen?</Element>
-                        </div>
+                        <>
+                            <div className={styles.overskrift}>
+                                <VarselIkon className={styles.varselIkon} />
+                                <Element className={styles.tekst}>Er du interessert i denne stillingen?</Element>
+                            </div>
+                            <p className={styles.ingress}>
+                                Du bestemmer selv om nav skal dele CV-en din på denne stillingen
+                            </p>
+                        </>
                     }
                     radios={[
                         {
                             label: 'Ja, og NAV kan dele CV-en min med arbeidsgiver',
-                            value: 'ja',
+                            value: SvarType.JA.toString(),
                             id: SvarType.JA.toString(),
                         },
                         {
                             label: 'Nei, og jeg vil ikke at NAV skal dele CV-en min med arbeidsgiveren',
-                            value: 'nei',
+                            value: SvarType.NEI.toString(),
                             id: SvarType.NEI.toString(),
                         },
                     ]}
-                    checked={svar}
+                    checked={svar?.toString()}
                     onChange={onChange}
                 />
-                <Hovedknapp mini className={styles.knapp}>
+                {infoTekst && (
+                    <AlertStripe type="info" form="inline" className={styles.infoboks}>
+                        {infoTekst}
+                    </AlertStripe>
+                )}
+                <Hovedknapp mini className={styles.knapp} onClick={onClick} disabled={!svar}>
                     Lagre
                 </Hovedknapp>
             </div>

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/MeldInteresseForStillingen.module.less
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/MeldInteresseForStillingen.module.less
@@ -1,16 +1,4 @@
-.varselIkon {
-    margin-right: 2px;
-    margin-top: 4px;
-}
-
-.overskrift {
-    display: flex;
-    align-items: flex-end;
-}
-
-.tekst {
-    margin-left: 0.75rem;
-}
+@import '~nav-frontend-core/less/_variabler';
 
 .knapp {
     margin-top: 1rem;
@@ -22,9 +10,6 @@
 
 .ingress {
     font-size: 14px;
-    font-style: normal;
     font-weight: 400;
-    line-height: 20px;
-    letter-spacing: 0.20000000298023224px;
-    text-align: left;
+    color: @navGra80;
 }

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/MeldInteresseForStillingen.module.less
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/MeldInteresseForStillingen.module.less
@@ -4,15 +4,27 @@
 }
 
 .overskrift {
-    margin-right: 0.6rem;
     display: flex;
     align-items: flex-end;
 }
 
 .tekst {
-    margin-left: 0.3rem;
+    margin-left: 0.75rem;
 }
 
 .knapp {
     margin-top: 1rem;
+}
+
+.infoboks {
+    margin-top: 1rem;
+}
+
+.ingress {
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 20px;
+    letter-spacing: 0.20000000298023224px;
+    text-align: left;
 }

--- a/src/moduler/aktivitet/visning/status-oppdatering/oppdater-aktivitet-status.tsx
+++ b/src/moduler/aktivitet/visning/status-oppdatering/oppdater-aktivitet-status.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Dispatch } from 'redux';
 
 import { STATUS_AVBRUTT, STATUS_FULLFOERT } from '../../../../constant';
-import { Aktivitet } from '../../../../datatypes/aktivitetTypes';
+import { Aktivitet, AktivitetStatus } from '../../../../datatypes/aktivitetTypes';
 import { flyttetAktivitetMetrikk } from '../../../../felles-komponenter/utils/logging';
 import { selectErUnderOppfolging } from '../../../oppfolging-status/oppfolging-selector';
 import { flyttAktivitetMedBegrunnelse } from '../../aktivitet-actions';
@@ -21,7 +21,11 @@ const useDisableStatusEndring = (aktivitet: Aktivitet) => {
     return lasterAktivitet || !underOppfolging || !kanEndreAktivitet;
 };
 
-const lagreStatusEndringer = (dispatch: Dispatch, values: any, aktivitet: Aktivitet) => {
+export const lagreStatusEndringer = (
+    dispatch: Dispatch,
+    values: { aktivitetstatus: AktivitetStatus; begrunnelse?: string },
+    aktivitet: Aktivitet
+) => {
     if (values.aktivitetstatus === aktivitet.status) {
         return Promise.resolve();
     }


### PR DESCRIPTION
* Flytter aktivitetskort basert på hva man angir som svar på spm om å dele cv. Bruker nå samme funksjon som den som vanligvis flytter aktivitetskort og medfølgende metrikker
* Flytter ut custom "overskrift" alertstripe som benyttes av både ulestmarkering og som overskrift i denne komponenten. De er like utenom luft mellom ikon og tekst
* Benytter predefinerte konstanter til aktivitetstatus type for å gjøre det mer typesikkert fram til alt som benytter typen er i ts.

Visning av svar som er angitt er fortsatt ikke implementert