### PR TITLE
Styler VarselIkon isteden for tekst i CustomAlertstripe isteden for å bruke !important i stylingen

### DIFF
--- a/src/moduler/aktivitet/ulest-markering/UlestMarkering.module.less
+++ b/src/moduler/aktivitet/ulest-markering/UlestMarkering.module.less
@@ -4,6 +4,6 @@
     align-items: flex-end;
 }
 
-.ulestTekst {
-    margin-left: 0.3rem;
+.varselIkon {
+    margin-right: 0.3rem;
 }

--- a/src/moduler/aktivitet/ulest-markering/UlestMarkering.tsx
+++ b/src/moduler/aktivitet/ulest-markering/UlestMarkering.tsx
@@ -14,7 +14,7 @@ const UlestMarkering = (props: Props) => {
     }
 
     return (
-        <CustomAlertstripe tekst="Ulest" sectionClassName={styles.ulestMarkering} textClassName={styles.ulestTekst} />
+        <CustomAlertstripe tekst="Ulest" sectionClassName={styles.ulestMarkering} ikonClassName={styles.varselIkon} />
     );
 };
 

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/CustomAlertstripe.module.less
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/CustomAlertstripe.module.less
@@ -3,6 +3,6 @@
     align-items: flex-end;
 }
 
-.tekst {
-    margin-left: 0.75rem !important;
+.ikon {
+    margin-right: 0.75rem;
 }

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/CustomAlertstripe.tsx
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/CustomAlertstripe.tsx
@@ -7,12 +7,12 @@ import styles from './CustomAlertstripe.module.less';
 interface Props {
     tekst: string;
     sectionClassName?: string;
-    textClassName?: string;
+    ikonClassName?: string;
 }
 
 export const CustomAlertstripe = (props: Props) => (
     <div className={props.sectionClassName ? props.sectionClassName : styles.overskrift}>
-        <VarselIkon />
-        <Element className={props.textClassName ? props.textClassName : styles.tekst}>{props.tekst}</Element>
+        <VarselIkon className={props.ikonClassName ? props.ikonClassName : styles.ikon} />
+        <Element>{props.tekst}</Element>
     </div>
 );


### PR DESCRIPTION
for at styling ikke skal bli overstyrt i fss.
Fungerer allerede med !important styling men gjør forsøk på endring for å unngå det