### PR TITLE
Strenge beskjeder: ny popup + bugfiks

### DIFF
--- a/src/datatypes/aktivitetTypes.ts
+++ b/src/datatypes/aktivitetTypes.ts
@@ -205,5 +205,5 @@ export enum ForhaandsorienteringType {
 export interface Forhaandsorientering {
     type: ForhaandsorienteringType;
     tekst: string;
-    lestDato?: string;
+    lest?: string;
 }

--- a/src/felles-komponenter/ekspanderbar-linje/EkspanderbarLinjeBase.tsx
+++ b/src/felles-komponenter/ekspanderbar-linje/EkspanderbarLinjeBase.tsx
@@ -36,7 +36,7 @@ const EkspanderbarLinjeBase = (props: PropsBase) => {
         aapenRef.current = erAapen;
     }, [erAapen]);
 
-    const tittelUtifraState = erAapen ? aapneTittel : tittel;
+    const tittelUtifraState = erAapen && aapneTittel ? aapneTittel : tittel;
     const tittelKomponent =
         typeof tittelUtifraState === 'string' ? <Normaltekst>{tittelUtifraState}</Normaltekst> : tittelUtifraState;
 

--- a/src/mocks/aktivitet.js
+++ b/src/mocks/aktivitet.js
@@ -217,7 +217,7 @@ const testAktiviteter = !visTestAktiviteter()
               forhaandsorientering: {
                   tekst: 'Det er viktig at du gjennomfører denne aktiviteten med NAV. Gjør du ikke det, kan det medføre at stønaden du mottar fra NAV bortfaller for en periode eller stanses. Hvis du ikke kan gjennomføre aktiviteten, ber vi deg ta kontakt med veilederen din så snart som mulig.',
                   type: 'SEND_FORHAANDSORIENTERING',
-                  lestDato: null,
+                  lest: null,
               },
           }),
           wrapAktivitet({
@@ -263,7 +263,7 @@ const testAktiviteter = !visTestAktiviteter()
               forhaandsorientering: {
                   tekst: 'Det er viktig at du gjennomfører denne aktiviteten med NAV. Gjør du ikke det, kan det medføre at stønaden du mottar fra NAV bortfaller for en periode eller stanses. Hvis du ikke kan gjennomføre aktiviteten, ber vi deg ta kontakt med veilederen din så snart som mulig.',
                   type: 'SEND_FORHAANDSORIENTERING',
-                  lestDato: '2021-05-30T10:46:40.459+00:00',
+                  lest: '2021-05-30T10:46:40.459+00:00',
               },
           }),
           wrapAktivitet({
@@ -789,7 +789,7 @@ export function oppdaterLestFho(__params, { aktivitetId }) {
     const nyeAktivitetAttributter = {
         forhaandsorientering: {
             ...gammelAktivitet.forhaandsorientering,
-            lestDato: moment().toISOString(),
+            lest: moment().toISOString(),
         },
         transaksjonsType: 'FORHAANDSORIENTERING_LEST',
     };

--- a/src/moduler/aktivitet/visning/AktivitetvisningModal.tsx
+++ b/src/moduler/aktivitet/visning/AktivitetvisningModal.tsx
@@ -66,8 +66,6 @@ const AktivitetvisningModal = (props: Props) => {
                     return;
                 }
                 if (skalLeses && fho) {
-                    console.log('skal leses: ', skalLeses);
-                    console.log('fho: ', fho);
                     window.alert('Det er en viktig beskjed om ansvaret ditt som du må lese.');
                     return;
                 }

--- a/src/moduler/aktivitet/visning/AktivitetvisningModal.tsx
+++ b/src/moduler/aktivitet/visning/AktivitetvisningModal.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
 import { STATUS_AVBRUTT, STATUS_FULLFOERT } from '../../../constant';
@@ -7,16 +7,13 @@ import { Aktivitet } from '../../../datatypes/aktivitetTypes';
 import Modal from '../../../felles-komponenter/modal/Modal';
 import ModalHeader from '../../../felles-komponenter/modal/ModalHeader';
 import { Avhengighet } from '../../../felles-komponenter/utils/Innholdslaster';
-import { loggForhaandsorienteringLest } from '../../../felles-komponenter/utils/logging';
 import { aktivitetStatusMap, aktivitetTypeMap } from '../../../utils/textMappers';
 import { DirtyContext } from '../../context/dirty-context';
 import { selectDialogFeilmeldinger } from '../../dialog/dialog-selector';
 import { selectErBruker } from '../../identitet/identitet-selector';
 import { selectNivaa4Feilmeldinger } from '../../tilgang/tilgang-selector';
-import { markerForhaandsorienteringSomLest } from '../aktivitet-actions';
 import { selectAktivitetFeilmeldinger } from '../aktivitet-selector';
 import { selectArenaFeilmeldinger } from '../arena-aktivitet-selector';
-import { markerForhaandsorienteringSomLestArenaAktivitet } from '../arena-aktiviteter-reducer';
 import { skalMarkereForhaandsorienteringSomLest } from './avtalt-container/utilsForhaandsorientering';
 
 const header = (valgtAktivitet?: Aktivitet) => {
@@ -47,7 +44,6 @@ const AktivitetvisningModal = (props: Props) => {
     const { aktivitet, avhengigheter, children } = props;
     const dirty = useContext(DirtyContext);
     const history = useHistory();
-    const dispatch = useDispatch();
     const selector = aktivitet?.arenaAktivitet ? selectArenaFeilmeldinger : selectAktivitetFeilmeldinger;
 
     const aktivitetFeil = useSelector(selector, shallowEqual);
@@ -58,15 +54,6 @@ const AktivitetvisningModal = (props: Props) => {
 
     const fho = aktivitet?.forhaandsorientering;
     const skalLeses = skalMarkereForhaandsorienteringSomLest(erBruker, aktivitet);
-
-    const markerFhoSomLest = () => {
-        if (aktivitet?.arenaAktivitet) {
-            dispatch(markerForhaandsorienteringSomLestArenaAktivitet(aktivitet));
-        } else {
-            dispatch(markerForhaandsorienteringSomLest(aktivitet));
-        }
-        aktivitet && loggForhaandsorienteringLest(aktivitet.type, false);
-    };
 
     return (
         <Modal
@@ -79,11 +66,10 @@ const AktivitetvisningModal = (props: Props) => {
                     return;
                 }
                 if (skalLeses && fho) {
-                    if (window.confirm(fho.tekst)) {
-                        markerFhoSomLest();
-                    } else {
-                        return;
-                    }
+                    console.log('skal leses: ', skalLeses);
+                    console.log('fho: ', fho);
+                    window.alert('Det er en viktig beskjed om ansvaret ditt som du må lese.');
+                    return;
                 }
                 history.push('/');
             }}

--- a/src/moduler/aktivitet/visning/avtalt-container/utilsForhaandsorientering.ts
+++ b/src/moduler/aktivitet/visning/avtalt-container/utilsForhaandsorientering.ts
@@ -24,7 +24,7 @@ export const skalMarkereForhaandsorienteringSomLest = (erBruker: boolean, aktivi
     const fho = aktivitet?.forhaandsorientering;
     return (
         !!fho?.type &&
-        !fho.lestDato &&
+        !fho.lest &&
         fho.type !== ForhaandsorienteringType.IKKE_SEND &&
         erBruker &&
         !aktivitet?.historisk &&

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/forhaandsorientering/Forhaandsorienteringsvisning.tsx
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/forhaandsorientering/Forhaandsorienteringsvisning.tsx
@@ -28,7 +28,7 @@ const Forhaandsorienteringsvisning = (props: Props) => {
 
     const forhaandsorientering = aktivitet.forhaandsorientering;
     const forhaandsorienteringTekst = forhaandsorientering?.tekst;
-    const forhaandsorienteringLestDato = forhaandsorientering?.lestDato;
+    const forhaandsorienteringLestDato = forhaandsorientering?.lest;
 
     const erLest = !!forhaandsorienteringLestDato;
 
@@ -76,7 +76,7 @@ const Forhaandsorienteringsvisning = (props: Props) => {
             kanToogle
         >
             <Tekstomrade className={styles.forhaandsorienteringTekst}>{forhaandsorienteringTekst}</Tekstomrade>
-            <LestDatoVisning hidden={!erLest} lestDato={forhaandsorienteringLestDato} />
+            <LestDatoVisning hidden={!erLest} lest={forhaandsorienteringLestDato} />
             <LestKnapp hidden={!kanMarkeresSomLest} onClick={onClickLestKnapp} lasterData={lasterData} />
         </EkspanderbarLinjeBase>
     );

--- a/src/moduler/aktivitet/visning/hjelpekomponenter/forhaandsorientering/LestDatoVisning.tsx
+++ b/src/moduler/aktivitet/visning/hjelpekomponenter/forhaandsorientering/LestDatoVisning.tsx
@@ -6,17 +6,17 @@ import styles from './LestDatoVisning.module.less';
 
 interface Props {
     hidden: boolean;
-    lestDato?: string;
+    lest?: string;
 }
 
 const LestDatoVisning = (props: Props) => {
-    const { hidden, lestDato } = props;
+    const { hidden, lest } = props;
 
     if (hidden) {
         return null;
     }
 
-    return <Undertekst className={styles.lestDato}>Lest {formaterDatoManed(lestDato)}</Undertekst>;
+    return <Undertekst className={styles.lestDato}>Lest {formaterDatoManed(lest)}</Undertekst>;
 };
 
 export default LestDatoVisning;

--- a/src/moduler/utskrift/print/aktiviteter/AktivitetPrint.tsx
+++ b/src/moduler/utskrift/print/aktiviteter/AktivitetPrint.tsx
@@ -32,7 +32,7 @@ const AktivitetPrint = (props: Props) => {
             <AvtaltMarkering hidden={!aktivitet.avtalt} className="etikett-print" />
             <ForhaandsorienteringPrint
                 forhaandsorienteringTekst={forhaandsorientering?.tekst}
-                forhaandsorienteringLest={forhaandsorientering?.lestDato}
+                forhaandsorienteringLest={forhaandsorientering?.lest}
             />
             <SokeStatusEtikett hidden={!aktivitet.etikett} etikett={aktivitet.etikett} className="etikett-print" />
             <DialogPrint dialog={dialog} />


### PR DESCRIPTION
- Ny popup hvis man ikke markerer FHO som lest før man lukker aktiviteten
- Fikse bug som gjorde at lestdato ikke lenger viste/oppdaterte seg riktig
- Fikse bug som gjorde at tittelen for streng beskjed ikke viste i åpen tilstand