### PR TITLE
Valideringsfeil når møte blir satt opp tidligere enn samme dag

### DIFF
--- a/src/felles-komponenter/skjema/datovelger/utils.ts
+++ b/src/felles-komponenter/skjema/datovelger/utils.ts
@@ -1,4 +1,4 @@
-import moment, { now } from 'moment';
+import moment from 'moment';
 
 import { erGyldigISODato, toDatePrettyPrint } from '../../../utils';
 
@@ -24,22 +24,5 @@ export const validerDato = (value: string | null, tidligsteFom?: string, seneste
         const prettyTil = toDatePrettyPrint(tilDato.toDate());
 
         return `Datoen må være innenfor perioden ${prettyFra}-${prettyTil}`;
-    }
-};
-
-export const validateTidligstDato = (value: string | null) => {
-    if (!value || value.trim().length === 0) {
-        return;
-    }
-
-    if (!erGyldigISODato(value)) {
-        return 'Datoen må være en gyldig dato på formatet dd.mm.åååå';
-    }
-
-    const inputDato = moment(value);
-    const tidligsteDato = moment(now());
-
-    if (tidligsteDato.isAfter(inputDato, 'day')) {
-        return `Datoen må tidligst være i dag`;
     }
 };

--- a/src/felles-komponenter/skjema/datovelger/utils.ts
+++ b/src/felles-komponenter/skjema/datovelger/utils.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment, { now } from 'moment';
 
 import { erGyldigISODato, toDatePrettyPrint } from '../../../utils';
 
@@ -24,5 +24,22 @@ export const validerDato = (value: string | null, tidligsteFom?: string, seneste
         const prettyTil = toDatePrettyPrint(tilDato.toDate());
 
         return `Datoen må være innenfor perioden ${prettyFra}-${prettyTil}`;
+    }
+};
+
+export const validateTidligstDato = (value: string | null) => {
+    if (!value || value.trim().length === 0) {
+        return;
+    }
+
+    if (!erGyldigISODato(value)) {
+        return 'Datoen må være en gyldig dato på formatet dd.mm.åååå';
+    }
+
+    const inputDato = moment(value);
+    const tidligsteDato = moment(now());
+
+    if (tidligsteDato.isAfter(inputDato, 'day')) {
+        return `Datoen må tidligst være i dag`;
     }
 };

--- a/src/moduler/aktivitet/aktivitet-forms/mote/MoteAktivitetForm.tsx
+++ b/src/moduler/aktivitet/aktivitet-forms/mote/MoteAktivitetForm.tsx
@@ -1,4 +1,5 @@
 import useFormstate from '@nutgaard/use-formstate';
+import moment, { now } from 'moment';
 import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 import Lenke from 'nav-frontend-lenker';
 import { SkjemaGruppe } from 'nav-frontend-skjema';
@@ -132,7 +133,12 @@ const MoteAktivitetForm = (props: Props) => {
                 <Input disabled={avtalt} label="Tema for møtet *" {...state.fields.tittel} />
 
                 <div className="mote-aktivitet-form__velg-mote-klokkeslett">
-                    <DatoField label="Dato *" {...state.fields.dato} required />
+                    <DatoField
+                        limitations={{ minDate: moment(now()).toISOString() }}
+                        label="Dato *"
+                        {...state.fields.dato}
+                        required
+                    />
                     <Input bredde="S" label="Klokkeslett *" {...state.fields.klokkeslett} type="time" step="300" />
                     <Input bredde="S" label="Varighet *" {...state.fields.varighet} type="time" step="900" />
                 </div>

--- a/src/moduler/aktivitet/aktivitet-forms/mote/MoteAktivitetForm.tsx
+++ b/src/moduler/aktivitet/aktivitet-forms/mote/MoteAktivitetForm.tsx
@@ -21,10 +21,10 @@ import {
     HENSIKT_MAKS_LENGDE,
     validateAdresse,
     validateForberedelser,
-    validateFraDato,
     validateHensikt,
     validateKanal,
     validateKlokkeslett,
+    validateMoteDato,
     validateTittel,
     validateVarighet,
 } from './validate';
@@ -81,14 +81,14 @@ const MoteAktivitetForm = (props: Props) => {
     const { aktivitet, isDirtyRef, onSubmit } = props;
 
     const validator = useFormstate<FormType, MoteAktivitet>({
-        tittel: (val, values, a) => validateTittel(a.avtalt, val),
-        dato: (val, values, a) => validateFraDato(a.avtalt, a.fraDato, val),
-        klokkeslett: (val, values, a) => validateKlokkeslett(a.avtalt, val),
-        varighet: (val, values, a) => validateVarighet(a.avtalt, val),
-        kanal: (val, values, a) => validateKanal(a.avtalt, val),
-        adresse: (val, values, a) => validateAdresse(a.avtalt, val),
-        beskrivelse: (val, values, a) => validateHensikt(a.avtalt, val),
-        forberedelser: (val, values, a) => validateForberedelser(a.avtalt, val),
+        tittel: (val, _, a) => validateTittel(a.avtalt, val),
+        dato: validateMoteDato,
+        klokkeslett: (val, _, a) => validateKlokkeslett(a.avtalt, val),
+        varighet: (val, _, a) => validateVarighet(a.avtalt, val),
+        kanal: (val, _, a) => validateKanal(a.avtalt, val),
+        adresse: (val, _, a) => validateAdresse(a.avtalt, val),
+        beskrivelse: (val, _, a) => validateHensikt(a.avtalt, val),
+        forberedelser: (val, _, a) => validateForberedelser(a.avtalt, val),
     });
 
     const maybeAktivitet = aktivitet || {};

--- a/src/moduler/aktivitet/aktivitet-forms/mote/validate.ts
+++ b/src/moduler/aktivitet/aktivitet-forms/mote/validate.ts
@@ -1,4 +1,6 @@
-import { validateTidligstDato } from '../../../../felles-komponenter/skjema/datovelger/utils';
+import moment, { now } from 'moment';
+
+import { validerDato } from '../../../../felles-komponenter/skjema/datovelger/utils';
 
 const TITTEL_MAKS_LENGDE = 100;
 const TITTEL_MAKS_LENGDE_TEKST = `Du må korte ned teksten til ${TITTEL_MAKS_LENGDE} tegn`;
@@ -31,7 +33,7 @@ export const validateTittel = (avtalt: boolean, value: string) => {
     }
 };
 
-export const validateAdresse = (avtalt: boolean, value: string) => {
+export const validateAdresse = (_avtalt: boolean, value: string) => {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut møtested eller annen praktisk informasjon';
     }
@@ -46,7 +48,11 @@ export const validateMoteDato = (value: string) => {
         return 'Du må fylle ut dato for møtet';
     }
 
-    return validateTidligstDato(value);
+    const fraDato = moment(value);
+
+    if (fraDato.isBefore(moment(now()), 'day')) return 'Datoen må tidligst være i dag';
+
+    return validerDato(value);
 };
 
 export const validateHensikt = (avtalt: boolean, value: string) => {
@@ -73,18 +79,18 @@ export const validateForberedelser = (avtalt: boolean, value: string) => {
     }
 };
 
-export const validateKlokkeslett = (avtalt: boolean, value: string) => {
+export const validateKlokkeslett = (_avtalt: boolean, value: string) => {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut klokkeslett';
     }
 };
 
-export const validateVarighet = (avtalt: boolean, value: string) => {
+export const validateVarighet = (_avtalt: boolean, value: string) => {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut varighet';
     }
 };
-export const validateKanal = (avtalt: boolean, value: string) => {
+export const validateKanal = (_avtalt: boolean, value: string) => {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut møteform';
     }

--- a/src/moduler/aktivitet/aktivitet-forms/mote/validate.ts
+++ b/src/moduler/aktivitet/aktivitet-forms/mote/validate.ts
@@ -1,4 +1,4 @@
-import { validerDato } from '../../../../felles-komponenter/skjema/datovelger/utils';
+import { validateTidligstDato } from '../../../../felles-komponenter/skjema/datovelger/utils';
 
 const TITTEL_MAKS_LENGDE = 100;
 const TITTEL_MAKS_LENGDE_TEKST = `Du må korte ned teksten til ${TITTEL_MAKS_LENGDE} tegn`;
@@ -41,12 +41,12 @@ export const validateAdresse = (avtalt: boolean, value: string) => {
     }
 };
 
-export const validateFraDato = (avtalt: boolean, tilDato: string, value: string) => {
+export const validateMoteDato = (value: string) => {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut dato for møtet';
     }
 
-    return validerDato(value, tilDato);
+    return validateTidligstDato(value);
 };
 
 export const validateHensikt = (avtalt: boolean, value: string) => {

--- a/src/moduler/aktivitet/aktivitet-forms/mote/validate.ts
+++ b/src/moduler/aktivitet/aktivitet-forms/mote/validate.ts
@@ -10,7 +10,7 @@ export const HENSIKT_MAKS_LENGDE = 5000;
 const HENSIKT_MAKS_LENGDE_TEKST = `Du må korte ned teksten til ${HENSIKT_MAKS_LENGDE} tegn`;
 export const FORBEREDELSER_MAKS_LENGDE = 500;
 const FORBEREDELSER_MAKS_LENGDE_TEKST = `Du må korte ned teksten til ${FORBEREDELSER_MAKS_LENGDE} tegn`;
-
+const INGEN_FEIL: string | undefined = undefined;
 const tekstForLang = (maxLengde: number, value: string) => {
     return value.length > maxLengde;
 };
@@ -21,7 +21,7 @@ const erVerdiSatt = (value: string) => {
 
 export const validateTittel = (avtalt: boolean, value: string) => {
     if (avtalt) {
-        return;
+        return INGEN_FEIL;
     }
 
     if (!erVerdiSatt(value)) {
@@ -42,7 +42,7 @@ export const validateAdresse = (_avtalt: boolean, value: string) => {
         return ADRESSE_MAKS_LENGDE_TEKST;
     }
 
-    return;
+    return INGEN_FEIL;
 };
 
 export const validateMoteDato = (value: string) => {
@@ -61,7 +61,7 @@ export const validateMoteDato = (value: string) => {
 
 export const validateHensikt = (avtalt: boolean, value: string) => {
     if (avtalt) {
-        return;
+        return INGEN_FEIL;
     }
 
     if (!erVerdiSatt(value)) {
@@ -75,7 +75,7 @@ export const validateHensikt = (avtalt: boolean, value: string) => {
 
 export const validateForberedelser = (avtalt: boolean, value: string) => {
     if (avtalt) {
-        return;
+        return INGEN_FEIL;
     }
 
     if (tekstForLang(FORBEREDELSER_MAKS_LENGDE, value)) {
@@ -87,19 +87,19 @@ export const validateKlokkeslett = (_avtalt: boolean, value: string) => {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut klokkeslett';
     }
-    return;
+    return INGEN_FEIL;
 };
 
 export const validateVarighet = (_avtalt: boolean, value: string) => {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut varighet';
     }
-    return;
+    return INGEN_FEIL;
 };
 
 export const validateKanal = (_avtalt: boolean, value: string) => {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut møteform';
     }
-    return;
+    return INGEN_FEIL;
 };

--- a/src/moduler/aktivitet/aktivitet-forms/mote/validate.ts
+++ b/src/moduler/aktivitet/aktivitet-forms/mote/validate.ts
@@ -41,6 +41,8 @@ export const validateAdresse = (_avtalt: boolean, value: string) => {
     if (tekstForLang(ADRESSE_MAKS_LENGDE, value)) {
         return ADRESSE_MAKS_LENGDE_TEKST;
     }
+
+    return;
 };
 
 export const validateMoteDato = (value: string) => {
@@ -50,7 +52,9 @@ export const validateMoteDato = (value: string) => {
 
     const fraDato = moment(value);
 
-    if (fraDato.isBefore(moment(now()), 'day')) return 'Datoen må tidligst være i dag';
+    if (fraDato.isBefore(moment(now()), 'day')) {
+        return 'Datoen må tidligst være i dag';
+    }
 
     return validerDato(value);
 };
@@ -83,15 +87,19 @@ export const validateKlokkeslett = (_avtalt: boolean, value: string) => {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut klokkeslett';
     }
+    return;
 };
 
 export const validateVarighet = (_avtalt: boolean, value: string) => {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut varighet';
     }
+    return;
 };
+
 export const validateKanal = (_avtalt: boolean, value: string) => {
     if (!erVerdiSatt(value)) {
         return 'Du må fylle ut møteform';
     }
+    return;
 };


### PR DESCRIPTION
* Ny møtevalidator for hvordan datoer for møter skal valideres
* Ny fellesvalidator som gir valideringsfeil når datoen er tidligere enn dagens dato
* Fjerner ubrukte parametre fra validering
* Oppdaterer gammel test som opprettet møte på fast dato i fortid
* Ny test for at møtedato i fortid gir valideringsvarsel