### PR TITLE
Bedre skille på erMerEnnEnManederSiden()

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -132,7 +132,7 @@ export function erMerEnnSyvDagerTil(dato) {
 }
 
 export function erMerEnnEnManederSiden(aktivitet) {
-    const datoVerdi = aktivitet.tilDato ? moment(aktivitet.tilDato) : moment(aktivitet.fraDato);
+    const datoVerdi = aktivitet.tilDato ? moment(aktivitet.tilDato) : moment(aktivitet.endretDato);
     return datoVerdi.isValid ? datoVerdi.isBefore(moment().subtract(1, 'month').startOf('day'), 'd') : false;
 }
 


### PR DESCRIPTION
Problemet med å bruke aktivitet.fraDato er at hvis man har en aktivitet som er påbegynt for to måneder siden, og redigerer den og er aktiv innen siste måneden, så blir ikke dette tatt høyde for i sorteringen. Det er bedre å bruke aktivitet.endretDato for å gjenspeile når det ble sist jobbet med.

Hvis jeg jobbet med en aktivitet aktivt i dag som ble påbegynt for to måneder siden, og markerer som "Fullført" eller "Avbrutt", vil den bli skjult under "Skjul aktiviteter eldre enn 1 måned" umiddelbart pga. aktivitet.fraDato. Dette er ikke intuitivt, og fører til at brukeren (meg) klør seg i hodet og prøver å fullføre/avbryte samme aktivitet (den øverste) en gang til, og ender opp med å ha fullført/avbrutt to aktiviteter på rad, altså én aktivitet brukeren (jeg) ikke skulle avbryte/fullføre.