### PR TITLE
Fix routing bug when linking from Dialog

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,10 +2,9 @@ import './index.less';
 
 import PT from 'prop-types';
 import React from 'react';
-import { HashRouter, BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, HashRouter } from 'react-router-dom';
 
 import Timeoutbox from './felles-komponenter/timeoutbox/timeoutbox';
-import createHistory from './history';
 import Hovedside from './hovedside/Hovedside';
 import Provider from './provider';
 import { HiddenIf, getContextPath } from './utils';
@@ -17,7 +16,6 @@ function isValueOrGetDefault(value, defaultValue) {
 
 export const AKTIVITETSPLAN_ROOT_NODE_ID = 'aktivitetsplan-app';
 
-const history = createHistory(getContextPath())
 // NOTE: This is bad, don't use it if you dont HAVE to.
 window.appconfig = window.appconfig || {};
 const path = window.appconfig.CONTEXT_PATH === '' ? '' : getContextPath();
@@ -29,25 +27,25 @@ window.appconfig = {
 };
 
 const getBasename = (fnr) => {
-    const pathnamePrefix = process.env.PUBLIC_URL
+    const pathnamePrefix = process.env.PUBLIC_URL;
     if (fnr && !pathnamePrefix) {
-        return fnr
+        return fnr;
     } else if (fnr && pathnamePrefix) {
-        return `${pathnamePrefix}/${fnr}`.replace('/', "") // Replace prepending slash
+        return `${pathnamePrefix}/${fnr}`.replace('/', ''); // Replace prepending slash
     } else if (pathnamePrefix) {
-        return pathnamePrefix
+        return pathnamePrefix;
     } else {
-        return undefined
+        return undefined;
     }
-}
+};
 
 function HashRouterIfGHPages({ fnr, children }) {
     if (process.env.REACT_APP_USE_HASH_ROUTER === 'true') {
-        return <HashRouter basename={fnr}>{children}</HashRouter>
+        return <HashRouter basename={fnr}>{children}</HashRouter>;
     }
 
-    const basename = getBasename(fnr)
-    return <BrowserRouter basename={basename} history={history}>{children}</BrowserRouter>;
+    const basename = getBasename(fnr);
+    return <BrowserRouter basename={basename}>{children}</BrowserRouter>;
 }
 
 function App({ fnr, key }) {

--- a/src/history.js
+++ b/src/history.js
@@ -1,8 +1,0 @@
-import { createBrowserHistory } from 'history';
-
-export default function createHistory(contextPath) {
-    const routerHistory = createBrowserHistory({
-        basename: contextPath
-    });
-    return routerHistory;
-}

--- a/src/hovedside/Hovedside.tsx
+++ b/src/hovedside/Hovedside.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { RouterProps, useHistory, withRouter } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { AnyAction } from 'redux';
 
 import AktivitetsplanRouting, { PublicRouting } from '../aktivitetsplanRouting';

--- a/src/hovedside/Hovedside.tsx
+++ b/src/hovedside/Hovedside.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { RouterProps, useHistory, withRouter } from 'react-router-dom';
 import { AnyAction } from 'redux';
 
+import AktivitetsplanRouting, { PublicRouting } from '../aktivitetsplanRouting';
+import { useEventListener } from '../felles-komponenter/hooks/useEventListner';
 import { hentDialog } from '../moduler/dialog/dialog-reducer';
 import HovedsideFeilmelding from '../moduler/feilmelding/HovedsideFeilmelding';
 import Nivaa4Feilmelding from '../moduler/feilmelding/IkkeNiva4';
@@ -12,10 +15,17 @@ import { hentEskaleringsvarsel } from '../moduler/varslinger/eskaleringsvarselRe
 import Varslinger from '../moduler/varslinger/Varslinger';
 import Navigasjonslinje from '../moduler/verktoylinje/navigasjonslinje';
 import Verktoylinje from '../moduler/verktoylinje/Verktoylinje';
-import AktivitetsplanRouting, { PublicRouting } from '../aktivitetsplanRouting';
+import { aktivitetRoute } from '../routes';
 import Aktivitetstavle from './tavle/Aktivitetstavle';
 
 const Hovedside = () => {
+    const history = useHistory();
+    useEventListener('visAktivitetsplan', (event) => {
+        const aktivitetId = event.detail as string | undefined;
+        if (!aktivitetId) return;
+        history.replace(aktivitetRoute(aktivitetId));
+    });
+
     const dispatch = useDispatch();
 
     useEffect(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,9 @@ import * as ReactDOM from 'react-dom';
 import ReactModal from 'react-modal';
 
 import App from './app';
-import {eksternBrukerConfig, veilederConfig} from './mocks/appconfig';
+import { eksternBrukerConfig, veilederConfig } from './mocks/appconfig';
 import DemoBanner from './mocks/demo/demoBanner';
-import {erEksternBruker} from './mocks/demo/sessionstorage';
+import { erEksternBruker } from './mocks/demo/sessionstorage';
 
 /* eslint-disable global-require */
 if (!global.Intl) {
@@ -26,12 +26,12 @@ moment.updateLocale('nb', {
     monthsShort: ['jan.', 'feb.', 'mar.', 'apr.', 'mai', 'jun.', 'jul.', 'aug.', 'sep.', 'okt.', 'nov.', 'des.'],
 });
 
-const usingHashRouting = process.env.REACT_APP_USE_HASH_ROUTER === "true";
+const usingHashRouting = process.env.REACT_APP_USE_HASH_ROUTER === 'true';
 
-export const mockfnr = "12345678910";
+export const mockfnr = '12345678910';
 if (process.env.REACT_APP_MOCK === 'true') {
     const fnr = mockfnr;
-    const pathnamePrefix = `${process.env.PUBLIC_URL}/${usingHashRouting ? "#/" : ""}`
+    const pathnamePrefix = `${process.env.PUBLIC_URL}/${usingHashRouting ? '#/' : ''}`;
 
     if (erEksternBruker()) {
         window.history.replaceState({}, '', pathnamePrefix);
@@ -46,12 +46,12 @@ if (process.env.REACT_APP_MOCK === 'true') {
     console.log('=========================='); // eslint-disable-line no-console
     require('./mocks'); // eslint-disable-line global-require
 
-    ReactDOM.render(<DemoBanner/>, document.getElementById('demo'));
+    ReactDOM.render(<DemoBanner />, document.getElementById('demo'));
 }
 
 function AppWrapper(props) {
-    if (process.env.REACT_APP_MOCK === "true") {
-        props = {...props, fnr: erEksternBruker() ? undefined : mockfnr}
+    if (process.env.REACT_APP_MOCK === 'true') {
+        props = { ...props, fnr: erEksternBruker() ? undefined : mockfnr };
     }
 
     // Må settes etter at dokumentet er parset

--- a/src/moduler/aktivitet/aktivitet-kort/Aktivitetskort.tsx
+++ b/src/moduler/aktivitet/aktivitet-kort/Aktivitetskort.tsx
@@ -58,8 +58,6 @@ const Aktivitetskort = (props: Props) => {
     const datoId = `aktivitetskort__dato__${id}`;
     const ariaLabel = `${aktivitetTypeMap[type]}: ${aktivitet.tittel}`;
 
-    console.log(aktivitetRoute(id))
-
     return (
         <LinkAsDiv
             id={prefixAktivtetskortId(aktivitet)}

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,4 +1,0 @@
-export const aktivitetRoute = (aktivitetId) => `/aktivitet/vis/${aktivitetId}`;
-export const endreAktivitetRoute = (aktivitetId) => `/aktivitet/endre/${aktivitetId}`;
-export const fullforAktivitetRoute = (aktivitetId) => `/aktivitet/fullfor/${aktivitetId}`;
-export const avbrytAktivitetRoute = (aktivitetId) => `/aktivitet/avbryt/${aktivitetId}`;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,4 @@
+export const aktivitetRoute = (aktivitetId: string) => `/aktivitet/vis/${aktivitetId}`;
+export const endreAktivitetRoute = (aktivitetId: string) => `/aktivitet/endre/${aktivitetId}`;
+export const fullforAktivitetRoute = (aktivitetId: string) => `/aktivitet/fullfor/${aktivitetId}`;
+export const avbrytAktivitetRoute = (aktivitetId: string) => `/aktivitet/avbryt/${aktivitetId}`;


### PR DESCRIPTION
Routing with `replaceState` does not trigger a react-router navigation. There is already an event we can use to trigger the navigation with includes aktivitetId