### PR TITLE
Legg til onClose på alle modaler

### DIFF
--- a/src/felles-komponenter/modal/Modal.tsx
+++ b/src/felles-komponenter/modal/Modal.tsx
@@ -16,6 +16,7 @@ interface Props {
     minstEnAvhengighet?: boolean;
     contentClass?: string;
     onRequestClose?(): boolean;
+    onClose?: () => void;
     tilbakeLenke?: { tekst: string; onTilbakeKlikk: MouseEventHandler };
 }
 
@@ -29,6 +30,7 @@ const Modal = (props: Props) => {
         minstEnAvhengighet = false,
         feilmeldinger,
         tilbakeLenke,
+        onClose,
     } = props;
 
     const navigate = useNavigate();
@@ -46,6 +48,7 @@ const Modal = (props: Props) => {
         <AkselModal
             closeOnBackdropClick
             open
+            onClose={onClose}
             onBeforeClose={closeFuncOrDefault}
             className="lg:w-120"
             aria-labelledby="modal-heading"

--- a/src/moduler/aktivitet/avslutt/AvbrytAktivitet.tsx
+++ b/src/moduler/aktivitet/avslutt/AvbrytAktivitet.tsx
@@ -40,7 +40,6 @@ const AvbrytAktivitet = () => {
             beskrivelseLabel={beskrivelseLabel}
             lagrer={lagrer}
             onSubmit={async (beskrivelseForm) => {
-                navigate(hovedsideRoute(), { replace: true });
                 lagreBegrunnelse(valgtAktivitet, beskrivelseForm.begrunnelse);
             }}
         />
@@ -48,7 +47,6 @@ const AvbrytAktivitet = () => {
 
     const advarsel = valgtAktivitet ? (
         <VisAdvarsel
-            headerTekst={headerTekst}
             onSubmit={() => {
                 lagreBegrunnelse(valgtAktivitet, null);
                 navigate(hovedsideRoute());
@@ -60,7 +58,7 @@ const AvbrytAktivitet = () => {
         valgtAktivitet && trengerBegrunnelse(valgtAktivitet.avtalt, AktivitetStatus.AVBRUTT, valgtAktivitet.type);
 
     return (
-        <Modal contentLabel="Avbryt aktivitet" heading={valgtAktivitet?.tittel || ''}>
+        <Modal onClose={() => navigate(hovedsideRoute(), { replace: true })} heading={'Avbryt aktivitet'}>
             {valgtAktivitet ? (
                 <PubliserReferat aktivitet={valgtAktivitet} nyStatus={AktivitetStatus.AVBRUTT}>
                     {maaBegrunnes ? begrunnelse : advarsel}

--- a/src/moduler/aktivitet/avslutt/FullforAktivitet.tsx
+++ b/src/moduler/aktivitet/avslutt/FullforAktivitet.tsx
@@ -4,7 +4,7 @@ import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { MOTE_TYPE, SAMTALEREFERAT_TYPE } from '../../../constant';
 import { Status } from '../../../createGenericSlice';
-import { AktivitetStatus } from '../../../datatypes/aktivitetTypes';
+import { AktivitetStatus, isArenaAktivitet } from '../../../datatypes/aktivitetTypes';
 import { VeilarbAktivitet } from '../../../datatypes/internAktivitetTypes';
 import useAppDispatch from '../../../felles-komponenter/hooks/useAppDispatch';
 import Modal from '../../../felles-komponenter/modal/Modal';
@@ -35,8 +35,11 @@ const FullforAktivitet = () => {
     const navigate = useNavigate();
     const { hovedsideRoute } = useRoutes();
 
+    if (!valgtAktivitet || isArenaAktivitet(valgtAktivitet)) return <Navigate to={hovedsideRoute()} />;
+
     const begrunnelse = (
         <BegrunnelseForm
+            headerTekst={headerTekst}
             beskrivelseLabel={beskrivelseTekst}
             lagrer={lagrer}
             onSubmit={async (beskrivelseForm) => {
@@ -49,18 +52,14 @@ const FullforAktivitet = () => {
 
     const advarsel = (
         <VisAdvarsel
-            headerTekst={headerTekst}
             onSubmit={() => {
                 valgtAktivitet && doAvsluttOppfolging(valgtAktivitet, null);
-                navigate(hovedsideRoute(), { replace: true });
             }}
         />
     );
 
-    if (!valgtAktivitet) return <Navigate to={hovedsideRoute()} />;
-
     return (
-        <Modal heading="Fullfør aktivitet">
+        <Modal onClose={() => navigate(hovedsideRoute(), { replace: true })} heading="Fullfør aktivitet">
             <PubliserReferat aktivitet={valgtAktivitet} nyStatus={AktivitetStatus.FULLFOERT}>
                 {valgtAktivitet.avtalt &&
                 valgtAktivitet.type !== SAMTALEREFERAT_TYPE &&

--- a/src/moduler/aktivitet/ny-aktivitet/LeggTilForm.tsx
+++ b/src/moduler/aktivitet/ny-aktivitet/LeggTilForm.tsx
@@ -7,16 +7,20 @@ import Modal from '../../../felles-komponenter/modal/Modal';
 import { useErVeileder } from '../../../Provider';
 import { useRoutes } from '../../../routes';
 import { selectAktivitetFeilmeldinger } from '../aktivitet-selector';
+import { useNavigate } from 'react-router-dom';
 
 const LeggTilForm = () => {
     const erVeileder = useErVeileder();
     const aktivitetFeilmeldinger = useSelector(selectAktivitetFeilmeldinger);
 
-    const { nyAktivitetRoute } = useRoutes();
+    const { nyAktivitetRoute, hovedsideRoute } = useRoutes();
+    const navigate = useNavigate();
+    const tilbake = () => navigate(hovedsideRoute());
     const nyAktivitetBasePath = nyAktivitetRoute();
 
     return (
         <Modal
+            onClose={tilbake}
             contentClass="ny-aktivitet-visning"
             feilmeldinger={aktivitetFeilmeldinger}
             heading="Legg til en aktivitet"

--- a/src/moduler/aktivitet/ny-aktivitet/NyAktivitetForm.tsx
+++ b/src/moduler/aktivitet/ny-aktivitet/NyAktivitetForm.tsx
@@ -44,6 +44,7 @@ const NyAktivitetForm = () => {
     const match = useMatch('/aktivitet/ny/:aktivitetType') as RouteMatch;
     const dispatch = useAppDispatch();
     const { aktivitetRoute, hovedsideRoute, nyAktivitetRoute } = useRoutes();
+    const tilHovedside = () => navigate(hovedsideRoute());
 
     const opprettFeil = useSelector(selectLagNyAktivitetFeil);
     const underOppfolging = useSelector(selectErUnderOppfolging);
@@ -93,6 +94,7 @@ const NyAktivitetForm = () => {
             heading={match?.params?.aktivitetType ? aktivitetHeadings[match.params.aktivitetType] : ''}
             tilbakeLenke={{ tekst: 'Til kategoriene', onTilbakeKlikk: onReqBack }}
             onRequestClose={onRequestClose}
+            onClose={tilHovedside}
         >
             <article>
                 <Routes>

--- a/src/moduler/aktivitet/rediger/EndreAktivitet.tsx
+++ b/src/moduler/aktivitet/rediger/EndreAktivitet.tsx
@@ -131,7 +131,6 @@ function EndreAktivitet() {
 
     const onReqClose = () => {
         if (!isDirty.current || window.confirm(CONFIRM)) {
-            navigate(hovedsideRoute());
             return true;
         }
         return false;
@@ -156,8 +155,11 @@ function EndreAktivitet() {
             ? getAktivitetsFormComponent(valgtAktivitet, { ...formProps, aktivitet: valgtAktivitet })
             : null;
 
+    const tilHovedside = () => navigate(hovedsideRoute());
+
     return (
         <Modal
+            onClose={tilHovedside}
             heading="Endre aktivitet"
             onRequestClose={onReqClose}
             tilbakeLenke={{ tekst: 'Tilbake', onTilbakeKlikk: onReqBack }}

--- a/src/moduler/aktivitet/visning/AktivitetvisningModal.tsx
+++ b/src/moduler/aktivitet/visning/AktivitetvisningModal.tsx
@@ -47,6 +47,7 @@ const AktivitetvisningModal = (props: Props) => {
     const dirty = useContext(DirtyContext);
     const navigate = useNavigate();
     const { hovedsideRoute } = useRoutes();
+    const tilHovedside = () => navigate(hovedsideRoute());
 
     const selectFeilMeldinger = (a: AlleAktiviteter) =>
         isArenaAktivitet(a) ? selectArenaFeilmeldinger : selectAktivitetFeilmeldinger;
@@ -63,6 +64,7 @@ const AktivitetvisningModal = (props: Props) => {
 
     return (
         <Modal
+            onClose={tilHovedside}
             avhengigheter={avhengigheter}
             subHeading={
                 aktivitet ? `${aktivitetStatusMap[aktivitet.status]} / ${getAktivitetType(aktivitet)}` : undefined

--- a/src/moduler/informasjon/informasjon-modal.tsx
+++ b/src/moduler/informasjon/informasjon-modal.tsx
@@ -15,6 +15,8 @@ import { OkonomiskStotte } from './okonomiskStottePanel';
 import { RettigheterPanel } from './rettigheterPanel';
 import { DialogPanel } from './dialogPanel';
 import IntroduksjonVideo from './Video/IntroduksjonVideo';
+import { useNavigate } from 'react-router-dom';
+import { useRoutes } from '../../routes';
 
 export const INFORMASJON_MODAL_VERSJON = 'v1';
 
@@ -25,6 +27,9 @@ interface Props {
 }
 
 const InformasjonModal = ({ erBruker, underOppfolging, lestInfo }: Props) => {
+    const navigate = useNavigate();
+    const { hovedsideRoute } = useRoutes();
+    const tilHovedside = () => navigate(hovedsideRoute());
     useEffect(() => {
         if (erBruker && underOppfolging && (!lestInfo || lestInfo.verdi !== INFORMASJON_MODAL_VERSJON)) {
             Api.postLest(INFORMASJON_MODAL_VERSJON);
@@ -32,7 +37,7 @@ const InformasjonModal = ({ erBruker, underOppfolging, lestInfo }: Props) => {
     }, []);
 
     return (
-        <Modal className="informasjon-visning" heading="Hva er aktivitetsplanen?">
+        <Modal onClose={tilHovedside} className="informasjon-visning" heading="Hva er aktivitetsplanen?">
             <ModalContainer className="max-w-2xl">
                 <BodyShort className="pb-4">
                     I aktivitetsplanen holder du oversikt over det du gjør for å komme i jobb eller annen aktivitet.

--- a/src/moduler/mal/mal-modal.tsx
+++ b/src/moduler/mal/mal-modal.tsx
@@ -3,6 +3,8 @@ import { useSelector } from 'react-redux';
 
 import Modal from '../../felles-komponenter/modal/Modal';
 import { selectHentMalListeFeil } from '../feilmelding/feil-selector';
+import { useNavigate } from 'react-router-dom';
+import { useRoutes } from '../../routes';
 
 interface Props {
     children: React.ReactNode;
@@ -13,9 +15,12 @@ interface Props {
 export function MalModal(props: Props) {
     const { children, heading } = props;
     const feil = useSelector(selectHentMalListeFeil);
+    const navigate = useNavigate();
+    const { hovedsideRoute } = useRoutes();
+    const tilHovedside = () => navigate(hovedsideRoute());
 
     return (
-        <Modal onRequestClose={props.onRequestClosed} feilmeldinger={feil} heading={heading}>
+        <Modal onClose={tilHovedside} onRequestClose={props.onRequestClosed} feilmeldinger={feil} heading={heading}>
             {children}
         </Modal>
     );

--- a/src/moduler/tilgang/tilgang-selector.ts
+++ b/src/moduler/tilgang/tilgang-selector.ts
@@ -3,6 +3,7 @@ import { RootState } from '../../store';
 import { selectErrors, selectFeil } from '../feilmelding/feil-selector';
 import { hentNivaa4 } from './tilgang-slice';
 import { createSelector } from 'reselect';
+import { SerializedError } from '../../api/utils';
 
 function selectTilgangSlice(state: RootState) {
     return state.data.tilgang;
@@ -25,7 +26,7 @@ export function selectNivaa4Status(state: RootState) {
     return selectTilgangSlice(state).status;
 }
 
-export const selectNivaa4Feilmeldinger: (state: RootState) => void = createSelector(
+export const selectNivaa4Feilmeldinger: (state: RootState) => SerializedError[] = createSelector(
     selectTilgangSlice,
     selectErrors,
     (tilgangSlice, errors) => {


### PR DESCRIPTION
url-ble feil når man lukket modaler med Esc-knapp istedetfor å trykke på krysset. Løsningen ble å flytte ut navigering til onClose der det gir mening. onClose blir alltid kalt når man lukker modalen, det blir ikke onRequestClose (ref bug-beskrivelse i aksel kanalen) 