### PR TITLE
Disable del-endring når referat ikke er endret

### DIFF
--- a/src/moduler/aktivitet/visning/referat/OppdaterReferatForm.tsx
+++ b/src/moduler/aktivitet/visning/referat/OppdaterReferatForm.tsx
@@ -106,7 +106,6 @@ const OppdaterReferatForm = (props: Props) => {
         lagreSamtalereferatKladdLagretAktivitet(referatValue);
     }, [referatValue]);
 
-    console.log('Isdirty ', isDirty);
     return (
         <form
             onSubmit={handleSubmit((values) => updateReferat(values))}

--- a/src/moduler/aktivitet/visning/referat/OppdaterReferatForm.tsx
+++ b/src/moduler/aktivitet/visning/referat/OppdaterReferatForm.tsx
@@ -106,6 +106,7 @@ const OppdaterReferatForm = (props: Props) => {
         lagreSamtalereferatKladdLagretAktivitet(referatValue);
     }, [referatValue]);
 
+    console.log('Isdirty ', isDirty);
     return (
         <form
             onSubmit={handleSubmit((values) => updateReferat(values))}
@@ -143,7 +144,7 @@ const OppdaterReferatForm = (props: Props) => {
                 <Button
                     variant={erReferatPublisert ? 'primary' : 'secondary'}
                     loading={oppdaterer}
-                    disabled={oppdaterer}
+                    disabled={oppdaterer || !isDirty}
                 >
                     {erReferatPublisert ? 'Del endring' : 'Lagre utkast'}
                 </Button>

--- a/src/moduler/aktivitet/visning/referat/ReferatContainer.test.tsx
+++ b/src/moduler/aktivitet/visning/referat/ReferatContainer.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { describe, it, expect } from 'vitest';
 
@@ -75,6 +75,34 @@ describe('ReferatContainer', () => {
             await findByText('Samtalereferat');
             expect(queryByText('Del med bruker')).toBeNull();
             expect(queryByText('Endre referat')).toBeNull();
+        });
+    });
+
+    describe('', () => {
+        it('"Del endring" knapp skal være disabled hvis referate ikke er endret', async () => {
+            const aktivitet = enSamtalereferatAktivitet({
+                status: AktivitetStatus.GJENNOMFOERT,
+                erReferatPublisert: true,
+            });
+            const { findByText } = renderReferatContainer(aktivitet);
+            const endreReferatKnapp = await findByText('Endre referat');
+            fireEvent.click(endreReferatKnapp);
+            const deleKnapp = await findByText('Del endring');
+            expect(deleKnapp.parentElement).toBeDisabled();
+        });
+
+        it('"Del endring" knapp skal IKKE være disabled hvis referate er endret', async () => {
+            const aktivitet = enSamtalereferatAktivitet({
+                status: AktivitetStatus.GJENNOMFOERT,
+                erReferatPublisert: true,
+            });
+            const { findByText, findByLabelText } = renderReferatContainer(aktivitet);
+            const endreReferatKnapp = await findByText('Endre referat');
+            fireEvent.click(endreReferatKnapp);
+            const samtaleReferatTextArea = await findByLabelText('Samtalereferat');
+            fireEvent.change(samtaleReferatTextArea, { target: { value: 'Ny tekst' } });
+            const deleKnapp = await findByText('Del endring');
+            expect(deleKnapp.parentElement).not.toBeDisabled();
         });
     });
 });


### PR DESCRIPTION
Jeg klarte å lage "tomme" historikk-innslag ved å trykke på "Del endring" når referatet ikke var endret, prøver å fikse det med å legge inn sperre i frontend
<img width="307" height="265" alt="Skjermbilde 2026-08-05 kl  11 59 46" src="https://github.com/user-attachments/assets/3f467967-813b-4c79-acec-16e10ec64a9e" />
